### PR TITLE
Add debug statements to tests

### DIFF
--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -22,4 +22,10 @@ set -x
 # This workaround is here until we don't figure out cause
 go mod tidy
 go mod vendor
+
+# Make sure kustomize and controller-gen are installed before running the tests
+# ToDo: Remove later, should not be required.
+make kustomize
+make controller-gen
+
 make test-integration

--- a/tests/integration/pkg/deploy/controller.go
+++ b/tests/integration/pkg/deploy/controller.go
@@ -46,7 +46,7 @@ func (w *Deployment) DeployDevfileRegistryOperator() error {
 	output, err := cmd.CombinedOutput()
 	fmt.Println(string(output))
 	if err != nil && !strings.Contains(string(output), "AlreadyExists") {
-		fmt.Println(err)
+		fmt.Println(err.Error())
 		return err
 	}
 
@@ -62,8 +62,9 @@ func (w *Deployment) DeployDevfileRegistryOperator() error {
 func (w *Deployment) InstallCustomResourceDefinitions() error {
 	devfileRegistryCRD := exec.Command("make", "install")
 	output, err := devfileRegistryCRD.CombinedOutput()
+	fmt.Println(string(output))
 	if err != nil && !strings.Contains(string(output), "AlreadyExists") {
-		fmt.Println(err)
+		fmt.Println(err.Error())
 		return err
 	}
 	return nil


### PR DESCRIPTION
- Prints the output of the command that installs the regisry CRDs
- Ensures kustomize and controller-gen are installed before running tests

Signed-off-by: John Collier <jcollier@redhat.com>