### PR TITLE
Use oc in integration tests

### DIFF
--- a/tests/integration/pkg/client/oc.go
+++ b/tests/integration/pkg/client/oc.go
@@ -20,9 +20,9 @@ import (
 	"github.com/devfile/registry-operator/tests/integration/pkg/config"
 )
 
-// KubectlApplyResource applies resources on the cluster, corresponding to the specified file(s)
-func (w *K8sClient) KubectlApplyResource(filePath string) (err error) {
-	cmd := exec.Command("kubectl", "apply", "--namespace", config.Namespace, "-f", filePath)
+// OcApplyResource applies resources on the cluster, corresponding to the specified file(s)
+func (w *K8sClient) OcApplyResource(filePath string) (err error) {
+	cmd := exec.Command("oc", "apply", "--namespace", config.Namespace, "-f", filePath)
 	outBytes, err := cmd.CombinedOutput()
 	output := string(outBytes)
 	if err != nil && !strings.Contains(output, "AlreadyExists") {
@@ -31,9 +31,9 @@ func (w *K8sClient) KubectlApplyResource(filePath string) (err error) {
 	return err
 }
 
-// KubectlDeleteResource deletes the resources from the cluster that the specified file(s) correspond to
-func (w *K8sClient) KubectlDeleteResource(filePath string) (err error) {
-	cmd := exec.Command("kubectl", "delete", "--namespace", config.Namespace, "-f", filePath)
+// OcDeleteResource deletes the resources from the cluster that the specified file(s) correspond to
+func (w *K8sClient) OcDeleteResource(filePath string) (err error) {
+	cmd := exec.Command("oc", "delete", "--namespace", config.Namespace, "-f", filePath)
 	outBytes, err := cmd.CombinedOutput()
 	output := string(outBytes)
 	if err != nil && !strings.Contains(output, "AlreadyExists") {

--- a/tests/integration/pkg/tests/devfileregistry_tests.go
+++ b/tests/integration/pkg/tests/devfileregistry_tests.go
@@ -32,7 +32,7 @@ var _ = ginkgo.Describe("[Create Devfile Registry resource]", func() {
 		label := "devfileregistry_cr=" + crName
 
 		// Deploy the devfileregistry resource for this test case and wait for the pod to be running
-		err := K8sClient.KubectlApplyResource("tests/integration/examples/create/devfileregistry.yaml")
+		err := K8sClient.OcApplyResource("tests/integration/examples/create/devfileregistry.yaml")
 		if err != nil {
 			ginkgo.Fail("Failed to create devfileregistry instance: " + err.Error())
 			return
@@ -55,7 +55,7 @@ var _ = ginkgo.Describe("[Create Devfile Registry resource]", func() {
 	})
 
 	var _ = ginkgo.AfterEach(func() {
-		K8sClient.KubectlDeleteResource("tests/integration/examples/create/devfileregistry.yaml")
+		K8sClient.OcDeleteResource("tests/integration/examples/create/devfileregistry.yaml")
 	})
 })
 
@@ -65,7 +65,7 @@ var _ = ginkgo.Describe("[Create Devfile Registry resource with TLS enabled]", f
 		label := "devfileregistry_cr=" + crName
 
 		// Deploy the devfileregistry resource for this test case and wait for the pod to be running
-		err := K8sClient.KubectlApplyResource("tests/integration/examples/create/devfileregistry-tls.yaml")
+		err := K8sClient.OcApplyResource("tests/integration/examples/create/devfileregistry-tls.yaml")
 		if err != nil {
 			ginkgo.Fail("Failed to create devfileregistry instance: " + err.Error())
 			return
@@ -91,7 +91,7 @@ var _ = ginkgo.Describe("[Create Devfile Registry resource with TLS enabled]", f
 	})
 
 	var _ = ginkgo.AfterEach(func() {
-		K8sClient.KubectlDeleteResource("tests/integration/examples/create/devfileregistry-tls.yaml")
+		K8sClient.OcDeleteResource("tests/integration/examples/create/devfileregistry-tls.yaml")
 	})
 })
 
@@ -101,7 +101,7 @@ var _ = ginkgo.Describe("[Update Devfile Registry resource]", func() {
 		label := "devfileregistry_cr=" + crName
 
 		// Deploy the devfileregistry resource for this test case and wait for the pod to be running
-		err := K8sClient.KubectlApplyResource("tests/integration/examples/update/devfileregistry-old.yaml")
+		err := K8sClient.OcApplyResource("tests/integration/examples/update/devfileregistry-old.yaml")
 		if err != nil {
 			ginkgo.Fail("Failed to create devfileregistry instance: " + err.Error())
 			return
@@ -123,7 +123,7 @@ var _ = ginkgo.Describe("[Update Devfile Registry resource]", func() {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 		// Update the devfileregistry resource for this test case
-		err = K8sClient.KubectlApplyResource("tests/integration/examples/update/devfileregistry-new.yaml")
+		err = K8sClient.OcApplyResource("tests/integration/examples/update/devfileregistry-new.yaml")
 		if err != nil {
 			ginkgo.Fail("Failed to create devfileregistry instance: " + err.Error())
 			return
@@ -140,6 +140,6 @@ var _ = ginkgo.Describe("[Update Devfile Registry resource]", func() {
 	})
 
 	var _ = ginkgo.AfterEach(func() {
-		K8sClient.KubectlDeleteResource("tests/integration/examples/update/devfileregistry-new.yaml")
+		K8sClient.OcDeleteResource("tests/integration/examples/update/devfileregistry-new.yaml")
 	})
 })


### PR DESCRIPTION
The OpenShift CI doesn't have Kubectl installed, so updating the integration tests to use `oc` instead of `kubectl`.