### PR TITLE
Update CI test script to use built operator image

### DIFF
--- a/.ci/openshift_integration.sh
+++ b/.ci/openshift_integration.sh
@@ -18,6 +18,9 @@ set -u
 # print each command before executing it
 set -x
 
+# Make sure we're running the integration tests with the image built by OpenShift CI
+export IMG=${REGISTRY_OPERATOR}
+
 # For some reason go on PROW force usage vendor folder
 # This workaround is here until we don't figure out cause
 go mod tidy


### PR DESCRIPTION
Updates the OpenShift CI test scripts for this repo so that the operator image built by the CI is used, rather than the one hosted on quay.io

@devfile/qe-team 