### PR TITLE
Miscellaneous improvements to the registry operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,53 @@ Issue tracking repo: https://github.com/devfile/api with label area/registry
 The controller can be deployed to a cluster provided you are logged in with cluster-admin credentials:
 
 ```bash
-export IMG=quay.io/devfile/registry-operator:next
 make install && make deploy
+```
+
+The operator will be installed under the `registry-operator-system` namespace. However, devfile registries can be deployed in any namespace.
+
+## Deploying a Devfile Registry
+
+Once the Devfile Registry operator has been deployed to a cluster, it's straightforward to deploy a Devfile Registry. The following samples below showcase how the registry can be deployed on to an OpenShift or Kubernetes cluster. 
+
+In addition to the examples below, the `samples/` folder in this repo provides some example devfile registry yaml files for convenience.
+
+
+### OpenShift
+
+Installing the devfile registry via the devfile registry operator on an OpenShift cluster can be done in one easy command:
+
+```bash
+$ cat <<EOF | oc apply -f -
+apiVersion: registry.devfile.io/v1alpha1
+kind: DevfileRegistry
+metadata:
+  name: devfile-registry
+spec:
+  devfileIndexImage: quay.io/devfile/devfile-index:next
+EOF
+```
+
+
+### Kubernetes
+
+Installing the devfile registry on a Kubernetes cluster is similar, but requires setting the `k8s.ingressDomain` field first.
+
+```bash
+$ export INGRESS_DOMAIN=<my-ingress-domain>
+
+$ cat <<EOF | kubectl apply -f -
+apiVersion: registry.devfile.io/v1alpha1
+kind: DevfileRegistry
+metadata:
+  name: devfile-registry
+spec:
+  devfileIndexImage: quay.io/devfile/devfile-index:next
+  tls:
+    enabled: false
+  k8s:
+    ingressDomain: $INGRESS_DOMAIN
+EOF
 ```
 
 ## Development

--- a/controllers/update.go
+++ b/controllers/update.go
@@ -30,8 +30,10 @@ import (
 func (r *DevfileRegistryReconciler) updateDeployment(ctx context.Context, cr *registryv1alpha1.DevfileRegistry, dep *appsv1.Deployment) error {
 	// Check to see if the existing devfile registry deployment needs to be updated
 	needsUpdating := false
-	if dep.Spec.Template.Spec.Containers[0].Image != cr.Spec.DevfileIndexImage {
-		dep.Spec.Template.Spec.Containers[0].Image = cr.Spec.DevfileIndexImage
+
+	indexImage := registry.GetDevfileIndexImage(cr)
+	if dep.Spec.Template.Spec.Containers[0].Image != indexImage {
+		dep.Spec.Template.Spec.Containers[0].Image = indexImage
 		needsUpdating = true
 	}
 	ociImage := registry.GetOCIRegistryImage(cr)

--- a/pkg/registry/defaults.go
+++ b/pkg/registry/defaults.go
@@ -19,7 +19,7 @@ import (
 const (
 	// Default image:tags
 	DefaultDevfileIndexImage = "quay.io/devfile/devfile-index:next"
-	DefaultOCIRegistryImage  = "registry:2.7.1"
+	DefaultOCIRegistryImage  = "quay.io/devfile/oci-registry:next"
 
 	// Defaults/constants for devfile registry storages
 	DefaultDevfileRegistryVolumeSize = "1Gi"
@@ -29,10 +29,12 @@ const (
 	DevfileRegistryTLSEnabled = true
 
 	// Defaults/constants for devfile registry services
-	DevfileIndexPortName   = "devfile-registry-metadata"
-	DevfileIndexPort       = 8080
-	DevfileMetricsPortName = "devfile-registry-metrics"
-	DevfileMetricsPort     = 5001
+	DevfileIndexPortName        = "devfile-registry-metadata"
+	DevfileIndexPort            = 8080
+	DevfileIndexMetricsPortName = "devfile-index-metrics"
+	DevfileIndexMetricsPort     = 7071
+	OCIMetricsPortName          = "oci-registry-metrics"
+	OCIMetricsPort              = 5001
 )
 
 func GetOCIRegistryImage(cr *registryv1alpha1.DevfileRegistry) string {
@@ -40,6 +42,13 @@ func GetOCIRegistryImage(cr *registryv1alpha1.DevfileRegistry) string {
 		return cr.Spec.OciRegistryImage
 	}
 	return DefaultOCIRegistryImage
+}
+
+func GetDevfileIndexImage(cr *registryv1alpha1.DevfileRegistry) string {
+	if cr.Spec.DevfileIndexImage != "" {
+		return cr.Spec.DevfileIndexImage
+	}
+	return DefaultDevfileIndexImage
 }
 
 func getDevfileRegistryVolumeSize(cr *registryv1alpha1.DevfileRegistry) string {

--- a/pkg/registry/service.go
+++ b/pkg/registry/service.go
@@ -30,8 +30,12 @@ func GenerateService(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Schem
 					Port: DevfileIndexPort,
 				},
 				{
-					Name: DevfileMetricsPortName,
-					Port: DevfileMetricsPort,
+					Name: DevfileIndexMetricsPortName,
+					Port: DevfileIndexMetricsPort,
+				},
+				{
+					Name: OCIMetricsPortName,
+					Port: OCIMetricsPort,
 				},
 			},
 			Selector: labels,

--- a/samples/registry-k8s.yaml
+++ b/samples/registry-k8s.yaml
@@ -1,0 +1,11 @@
+apiVersion: registry.devfile.io/v1alpha1
+kind: DevfileRegistry
+metadata:
+  name: devfile-registry
+spec:
+  devfileIndexImage: quay.io/devfile/devfile-index:next
+  tls:
+    enabled: false
+  k8s:
+    ingressDomain: $ingressdomain
+  

--- a/samples/registry-no-storage.yaml
+++ b/samples/registry-no-storage.yaml
@@ -1,0 +1,8 @@
+apiVersion: registry.devfile.io/v1alpha1
+kind: DevfileRegistry
+metadata:
+  name: devfile-registry
+spec:
+  devfileIndexImage: quay.io/devfile/devfile-index:next
+  storage:
+    enabled: false

--- a/samples/registry.yaml
+++ b/samples/registry.yaml
@@ -1,0 +1,7 @@
+apiVersion: registry.devfile.io/v1alpha1
+kind: DevfileRegistry
+metadata:
+  name: devfile-registry
+spec:
+  devfileIndexImage: quay.io/devfile/devfile-index:next
+  

--- a/tests/integration/pkg/tests/devfileregistry_tests.go
+++ b/tests/integration/pkg/tests/devfileregistry_tests.go
@@ -54,12 +54,19 @@ var _ = ginkgo.Describe("[Create Devfile Registry resource]", func() {
 		err = util.WaitForServer(registry.Status.URL, 30*time.Second)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-		// Verify that the metrics endpoint is running
+		// Verify that the index metrics endpoint is running
 		podList, err := K8sClient.ListPods(config.Namespace, label)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		registryPod := podList.Items[0]
-		metricsURL := "http://localhost:5001/metrics"
-		output, err := K8sClient.CurlEndpointInContainer(registryPod.Name, "devfile-registry-bootstrap", metricsURL)
+
+		indexMetricsURL := "http://localhost:7071/metrics"
+		output, err := K8sClient.CurlEndpointInContainer(registryPod.Name, "devfile-registry-bootstrap", indexMetricsURL)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(output).To(gomega.ContainSubstring("promhttp_metric_handler_requests_total"))
+
+		// Verify that the oci metrics endpoint is running
+		ociMetricsURL := "http://localhost:5001/metrics"
+		output, err = K8sClient.CurlEndpointInContainer(registryPod.Name, "devfile-registry-bootstrap", ociMetricsURL)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(output).To(gomega.ContainSubstring("registry_storage_cache_total"))
 	})


### PR DESCRIPTION
- Update readme to add section on deploying the registry on both Kubernetes and OpenShift
- Make sure the index server's metrics port is enabled in the Kubernetes Service
- Make sure the default image for the devfile index image is set
- Updates test to check that both the index and oci metrics servers are running, and not just the oci one