### PR TITLE
Add telemetry option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ metadata:
   name: devfile-registry
 spec:
   devfileIndexImage: quay.io/devfile/devfile-index:next
+  telemetry:
+    enabled: true
+    registry: test
 EOF
 ```
 
@@ -57,6 +60,9 @@ spec:
     enabled: false
   k8s:
     ingressDomain: $INGRESS_DOMAIN
+  telemetry:
+    enabled: true
+    registry: test
 EOF
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ spec:
   devfileIndexImage: quay.io/devfile/devfile-index:next
   telemetry:
     enabled: true
-    registry: test
+    registryName: test
 EOF
 ```
 
@@ -62,7 +62,7 @@ spec:
     ingressDomain: $INGRESS_DOMAIN
   telemetry:
     enabled: true
-    registry: test
+    registryName: test
 EOF
 ```
 

--- a/api/v1alpha1/devfileregistry_types.go
+++ b/api/v1alpha1/devfileregistry_types.go
@@ -72,7 +72,7 @@ type DevfileRegistrySpecTelemetry struct {
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 
-	// Registry name, the registry name can be any string and we only use it as identifier for telemetry
+	// The registry name (can be any string) that is used as identifier for devfile telemetry.
 	// +optional
 	RegistryName string `json:"registryName"`
 }

--- a/api/v1alpha1/devfileregistry_types.go
+++ b/api/v1alpha1/devfileregistry_types.go
@@ -27,10 +27,11 @@ type DevfileRegistrySpec struct {
 	// Overrides the container image used for the OCI registry.
 	// Recommended to leave blank and default to the image specified by the operator.
 	// +optional
-	OciRegistryImage string                     `json:"ociRegistryImage,omitempty"`
-	Storage          DevfileRegistrySpecStorage `json:"storage,omitempty"`
-	TLS              DevfileRegistrySpecTLS     `json:"tls,omitempty"`
-	K8s              DevfileRegistrySpecK8sOnly `json:"k8s,omitempty"`
+	OciRegistryImage string                       `json:"ociRegistryImage,omitempty"`
+	Storage          DevfileRegistrySpecStorage   `json:"storage,omitempty"`
+	TLS              DevfileRegistrySpecTLS       `json:"tls,omitempty"`
+	K8s              DevfileRegistrySpecK8sOnly   `json:"k8s,omitempty"`
+	Telemetry        DevfileRegistrySpecTelemetry `json:"telemetry,omitempty"`
 }
 
 // DevfileRegistrySpecStorage defines the desired state of the storage for the DevfileRegistry
@@ -62,6 +63,18 @@ type DevfileRegistrySpecTLS struct {
 type DevfileRegistrySpecK8sOnly struct {
 	// Ingress domain for a Kubernetes cluster. This MUST be explicitly specified on Kubernetes. There are no defaults
 	IngressDomain string `json:"ingressDomain,omitempty"`
+}
+
+// Telemetry defines the desired state for telemetry in the DevfileRegistry
+type DevfileRegistrySpecTelemetry struct {
+	// Instructs the operator to deploy the DevfileRegistry with telemetry enabled.
+	// Disabled by default. Enabling is recommended for registry improvement.
+	// +optional
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Registry name
+	// +optional
+	Registry string `json:"registry"`
 }
 
 // DevfileRegistryStatus defines the observed state of DevfileRegistry

--- a/api/v1alpha1/devfileregistry_types.go
+++ b/api/v1alpha1/devfileregistry_types.go
@@ -72,9 +72,9 @@ type DevfileRegistrySpecTelemetry struct {
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 
-	// Registry name
+	// Registry name, the registry name can be any string and we only use it as identifier for telemetry
 	// +optional
-	Registry string `json:"registry"`
+	RegistryName string `json:"registryName"`
 }
 
 // DevfileRegistryStatus defines the observed state of DevfileRegistry

--- a/config/crd/bases/registry.devfile.io_devfileregistries.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistries.yaml
@@ -76,6 +76,19 @@ spec:
                     volume, if enabled. Defaults to 1Gi.
                   type: string
               type: object
+            telemetry:
+              description: Telemetry defines the desired state for telemetry in the
+                DevfileRegistry
+              properties:
+                enabled:
+                  description: Instructs the operator to deploy the DevfileRegistry
+                    with telemetry enabled. Disabled by default. Enabling is recommended
+                    for registry improvement.
+                  type: boolean
+                registry:
+                  description: Registry name
+                  type: string
+              type: object
             tls:
               description: DevfileRegistrySpecTLS defines the desired state for TLS
                 in the DevfileRegistry

--- a/config/crd/bases/registry.devfile.io_devfileregistries.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistries.yaml
@@ -85,8 +85,9 @@ spec:
                     with telemetry enabled. Disabled by default. Enabling is recommended
                     for registry improvement.
                   type: boolean
-                registry:
-                  description: Registry name
+                registryName:
+                  description: The registry name (can be any string) that is used
+                    as identifier for devfile telemetry.
                   type: string
               type: object
             tls:

--- a/pkg/registry/defaults.go
+++ b/pkg/registry/defaults.go
@@ -26,7 +26,8 @@ const (
 	DevfileRegistryVolumeEnabled     = true
 	DevfileRegistryVolumeName        = "devfile-registry-storage"
 
-	DevfileRegistryTLSEnabled = true
+	DevfileRegistryTLSEnabled       = true
+	DevfileRegistryTelemetryEnabled = false
 
 	// Defaults/constants for devfile registry services
 	DevfileIndexPortName        = "devfile-registry-metadata"
@@ -86,4 +87,13 @@ func IsTLSEnabled(cr *registryv1alpha1.DevfileRegistry) bool {
 		return *cr.Spec.TLS.Enabled
 	}
 	return DevfileRegistryTLSEnabled
+}
+
+// IsTelemetryEnabled returns true if telemetry.enabled is set in the DevfileRegistry CR
+// If it's not set, it returns false by default
+func IsTelemetryEnabled(cr *registryv1alpha1.DevfileRegistry) bool {
+	if cr.Spec.Telemetry.Enabled != nil {
+		return *cr.Spec.Telemetry.Enabled
+	}
+	return DevfileRegistryTelemetryEnabled
 }

--- a/pkg/registry/deployment.go
+++ b/pkg/registry/deployment.go
@@ -12,6 +12,8 @@
 package registry
 
 import (
+	"strconv"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -69,6 +71,16 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 										Path: "/health",
 										Port: intstr.FromInt(DevfileIndexPort),
 									},
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ENABLE_TELEMETRY",
+									Value: strconv.FormatBool(*cr.Spec.Telemetry.Enabled),
+								},
+								{
+									Name:  "REGISTRY",
+									Value: cr.Spec.Telemetry.Registry,
 								},
 							},
 						},

--- a/pkg/registry/deployment.go
+++ b/pkg/registry/deployment.go
@@ -76,11 +76,11 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 							Env: []corev1.EnvVar{
 								{
 									Name:  "ENABLE_TELEMETRY",
-									Value: strconv.FormatBool(*cr.Spec.Telemetry.Enabled),
+									Value: strconv.FormatBool(IsTelemetryEnabled(cr)),
 								},
 								{
-									Name:  "REGISTRY",
-									Value: cr.Spec.Telemetry.Registry,
+									Name:  "REGISTRY_NAME",
+									Value: cr.Spec.Telemetry.RegistryName,
 								},
 							},
 						},


### PR DESCRIPTION
This PR adds the telemetry option to consumer so that consumer can opt in/out the registry telemetry when using operator to deploy the registry.

Signed-off-by: Jingfu Wang <jingfwan@redhat.com>