### PR TITLE
Deployment bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ GOBIN=$(shell go env GOBIN)
 endif
 
 # Check if oc or kubectl are installed and determine which of the two to use
+ifeq ($(K8S_CLI),)
 ifeq (,$(shell which kubectl))
 ifeq (,$(shell which oc))
 $(error oc or kubectl is required to proceed)
@@ -38,6 +39,7 @@ K8S_CLI := oc
 endif
 else
 K8S_CLI := kubectl
+endif
 endif
 
 

--- a/config/crd/bases/registry.devfile.io_devfileregistries.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistries.yaml
@@ -95,6 +95,12 @@ spec:
                     description: The registry name (can be any string) that is used
                       as identifier for devfile telemetry.
                     type: string
+                  registryViewerWriteKey:
+                    description: Specify a telemetry write key for the registry viewer
+                      component to allow data to be sent to a client's own Segment
+                      analytics source. If the write key is specified then telemetry
+                      for the registry viewer component will be enabled
+                    type: string
                 type: object
               tls:
                 description: DevfileRegistrySpecTLS defines the desired state for

--- a/pkg/registry/configmap.go
+++ b/pkg/registry/configmap.go
@@ -52,7 +52,7 @@ http:
 
 	viewerEnvfile := fmt.Sprintf(`
 ANALYTICS_WRITE_KEY=%s
-DEVFILE_REGISTRIES=[{\"name\":\"Community\",\"url\":\"http://localhost:8080\",\"fqdn\":\"http://%s.%s\"}]`,
+DEVFILE_REGISTRIES=[{"name":"Community","url":"http://localhost:8080","fqdn":"http://%s.%s"}]`,
 		cr.Spec.Telemetry.RegistryViewerWriteKey, IngressName(cr.Name), cr.Spec.K8s.IngressDomain)
 
 	configMapData["registry-config.yml"] = registryConfig

--- a/pkg/registry/configmap.go
+++ b/pkg/registry/configmap.go
@@ -52,8 +52,8 @@ http:
 
 	viewerEnvfile := fmt.Sprintf(`
 ANALYTICS_WRITE_KEY=%s
-DEVFILE_REGISTRIES=[{"name":"Community","url":"http://localhost:8080","fqdn":"http://%s.%s"}]`,
-		cr.Spec.Telemetry.RegistryViewerWriteKey, IngressName(cr.Name), cr.Spec.K8s.IngressDomain)
+DEVFILE_REGISTRIES=[{"name":"Community","url":"http://localhost:8080","fqdn":"%s"}]`,
+		cr.Spec.Telemetry.RegistryViewerWriteKey, cr.Status.URL)
 
 	configMapData["registry-config.yml"] = registryConfig
 	configMapData[".env.registry-viewer"] = viewerEnvfile

--- a/pkg/registry/configmap.go
+++ b/pkg/registry/configmap.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2022 Red Hat, Inc.
+Copyright 2020-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/registry/defaults.go
+++ b/pkg/registry/defaults.go
@@ -44,6 +44,7 @@ const (
 	DevfileIndexMetricsPort     = 7071
 	OCIMetricsPortName          = "oci-registry-metrics"
 	OCIMetricsPort              = 5001
+	OCIServerPort               = 5000
 	RegistryViewerPort          = 3000
 )
 

--- a/pkg/registry/defaults.go
+++ b/pkg/registry/defaults.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2022 Red Hat, Inc.
+Copyright 2020-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/pkg/registry/deployment.go
+++ b/pkg/registry/deployment.go
@@ -17,6 +17,8 @@ limitations under the License.
 package registry
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -213,11 +215,22 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 					},
 				},
 			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "ANALYTICS_WRITE_KEY",
+					Value: cr.Spec.Telemetry.RegistryViewerWriteKey,
+				},
+				{
+					Name: "DEVFILE_REGISTRIES",
+					Value: fmt.Sprintf("[{\"name\":\"Community\",\"url\":\"http://localhost:8080\",\"fqdn\":\"%s\"}]",
+						cr.Status.URL),
+				},
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "viewer-env-file",
-					MountPath: "/app/apps/registry-viewer/.env.local",
-					SubPath:   ".env.local",
+					MountPath: "/app/.env.production",
+					SubPath:   ".env.production",
 				},
 			},
 		})
@@ -231,7 +244,7 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 					Items: []corev1.KeyToPath{
 						{
 							Key:  ".env.registry-viewer",
-							Path: ".env.local",
+							Path: ".env.production",
 						},
 					},
 				},

--- a/pkg/registry/deployment.go
+++ b/pkg/registry/deployment.go
@@ -34,6 +34,9 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 	replicas := int32(1)
 	allowPrivilegeEscalation := false
 	runAsNonRoot := true
+	runAsUser := int64(1001)
+	runAsGroup := int64(2001)
+	fsGroup := int64(3001)
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: generateObjectMeta(cr.Name, cr.Namespace, labels),
@@ -47,6 +50,12 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: &runAsNonRoot,
+						RunAsUser:    &runAsUser,
+						RunAsGroup:   &runAsGroup,
+						FSGroup:      &fsGroup,
+					},
 					Containers: []corev1.Container{
 						{
 							Image:           cr.Spec.DevfileIndexImage,

--- a/pkg/registry/deployment.go
+++ b/pkg/registry/deployment.go
@@ -30,6 +30,8 @@ import (
 
 func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Scheme, labels map[string]string) *appsv1.Deployment {
 	replicas := int32(1)
+	allowPrivilegeEscalation := false
+	runAsNonRoot := true
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: generateObjectMeta(cr.Name, cr.Namespace, labels),
@@ -48,6 +50,16 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 							Image:           cr.Spec.DevfileIndexImage,
 							ImagePullPolicy: corev1.PullAlways,
 							Name:            "devfile-registry",
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+								RunAsNonRoot:             &runAsNonRoot,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: "RuntimeDefault",
+								},
+							},
 							Ports: []corev1.ContainerPort{{
 								ContainerPort: DevfileIndexPort,
 							}},
@@ -91,6 +103,16 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 						{
 							Image: GetOCIRegistryImage(cr),
 							Name:  "oci-registry",
+							SecurityContext: &corev1.SecurityContext{
+								AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+								RunAsNonRoot:             &runAsNonRoot,
+								Capabilities: &corev1.Capabilities{
+									Drop: []corev1.Capability{"ALL"},
+								},
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: "RuntimeDefault",
+								},
+							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
 									corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -147,6 +169,16 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 			Image:           GetRegistryViewerImage(cr),
 			ImagePullPolicy: corev1.PullAlways,
 			Name:            "registry-viewer",
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: &allowPrivilegeEscalation,
+				RunAsNonRoot:             &runAsNonRoot,
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{"ALL"},
+				},
+				SeccompProfile: &corev1.SeccompProfile{
+					Type: "RuntimeDefault",
+				},
+			},
 			Resources: corev1.ResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("250m"),

--- a/pkg/registry/deployment.go
+++ b/pkg/registry/deployment.go
@@ -48,12 +48,6 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot: &runAsNonRoot,
-						RunAsUser:    &runAsUser,
-						RunAsGroup:   &runAsGroup,
-						FSGroup:      &fsGroup,
-					},
 					Containers: []corev1.Container{
 						{
 							Image:           cr.Spec.DevfileIndexImage,
@@ -267,6 +261,16 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 			Name:  "REGISTRY_HEADLESS",
 			Value: "true",
 		})
+	}
+
+	// Enables podspec security context if storage is enabled
+	if cr.Spec.Storage.Enabled == nil || *cr.Spec.Storage.Enabled {
+		dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsNonRoot: &runAsNonRoot,
+			RunAsUser:    &runAsUser,
+			RunAsGroup:   &runAsGroup,
+			FSGroup:      &fsGroup,
+		}
 	}
 
 	// Set DevfileRegistry instance as the owner and controller


### PR DESCRIPTION
**Please specify the area for this PR**

operator bugfix

**What does does this PR do / why we need it**:

Bugfix changes include:

- Removes unnecessary escape characters used on [pkg/registry/configmap.go#L55](https://github.com/devfile/registry-operator/blob/71b9284a12630989184a8cf926a97543ef8da65f/pkg/registry/configmap.go#L55) which cause the registry viewer to fail the JSON parsing process and fail to deploy. 
- Changes for devfile/api#1016 applied.
- Changes for devfile/api#1019 applied.
- Adds container security contexts required by OCP 4.12.
- Add pod security contexts if storage is enabled.
- Makefile now lets user override the `K8S_CLI` variable.
- Missing `registryViewerWriteKey` added to the devfile registries crd config.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#966, devfile/api#1014, devfile/api#1016, devfile/api#1019, devfile/api#1025

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the [registry operator documentation](https://github.com/devfile/devfile-web/tree/main/libs/docs/src/docs/no-version) need to updated with your changes?

**How to test changes / Special notes to the reviewer**:
