### PR TITLE
Fix environment variable definitions for registry viewer deployment

### DIFF
--- a/pkg/registry/deployment.go
+++ b/pkg/registry/deployment.go
@@ -17,6 +17,8 @@ limitations under the License.
 package registry
 
 import (
+	"fmt"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -181,11 +183,22 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 					},
 				},
 			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "ANALYTICS_WRITE_KEY",
+					Value: cr.Spec.Telemetry.RegistryViewerWriteKey,
+				},
+				{
+					Name: "DEVFILE_REGISTRIES",
+					Value: fmt.Sprintf(`[{\"name\":\"Community\",\"url\":\"http://localhost:8080\",\"fqdn\":\"http://%s.%s\"}]`,
+						IngressName(cr.Name), cr.Spec.K8s.IngressDomain),
+				},
+			},
 			VolumeMounts: []corev1.VolumeMount{
 				{
 					Name:      "viewer-env-file",
-					MountPath: "/app/apps/registry-viewer/.env.local",
-					SubPath:   ".env.local",
+					MountPath: "/app/.env.production",
+					SubPath:   ".env.production",
 				},
 			},
 		})
@@ -199,7 +212,7 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 					Items: []corev1.KeyToPath{
 						{
 							Key:  ".env.registry-viewer",
-							Path: ".env.local",
+							Path: ".env.production",
 						},
 					},
 				},


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

operator

**What does does this PR do / why we need it**:

Provides required fixes to setting environment variables on the registry viewer within the registry operator deployment.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1016

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the [registry operator documentation](https://github.com/devfile/devfile-web/tree/main/libs/docs/src/docs/no-version) need to updated with your changes?

**How to test changes / Special notes to the reviewer**:
