### PR TITLE
Probe changes in registry operator

### DIFF
--- a/pkg/registry/defaults.go
+++ b/pkg/registry/defaults.go
@@ -44,6 +44,7 @@ const (
 	DevfileIndexMetricsPort     = 7071
 	OCIMetricsPortName          = "oci-registry-metrics"
 	OCIMetricsPort              = 5001
+	OCIServerPort               = 5000
 	RegistryViewerPort          = 3000
 )
 


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

operator

**What does does this PR do / why we need it**:

Updates the probing in the registry operator template generation source to ensure the registry index server is ready before launching the registry viewer.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1019

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the [registry operator documentation](https://github.com/devfile/devfile-web/tree/main/libs/docs/src/docs/no-version) need to updated with your changes?

**How to test changes / Special notes to the reviewer**:
