### PR TITLE
Add podspec security context

### DIFF
--- a/pkg/registry/deployment.go
+++ b/pkg/registry/deployment.go
@@ -30,6 +30,10 @@ import (
 
 func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Scheme, labels map[string]string) *appsv1.Deployment {
 	replicas := int32(1)
+	runAsNonRoot := true
+	runAsUser := int64(1001)
+	runAsGroup := int64(2001)
+	fsGroup := int64(3001)
 
 	dep := &appsv1.Deployment{
 		ObjectMeta: generateObjectMeta(cr.Name, cr.Namespace, labels),
@@ -43,6 +47,12 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsNonRoot: &runAsNonRoot,
+						RunAsUser:    &runAsUser,
+						RunAsGroup:   &runAsGroup,
+						FSGroup:      &fsGroup,
+					},
 					Containers: []corev1.Container{
 						{
 							Image:           cr.Spec.DevfileIndexImage,

--- a/pkg/registry/deployment.go
+++ b/pkg/registry/deployment.go
@@ -47,12 +47,6 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
-					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot: &runAsNonRoot,
-						RunAsUser:    &runAsUser,
-						RunAsGroup:   &runAsGroup,
-						FSGroup:      &fsGroup,
-					},
 					Containers: []corev1.Container{
 						{
 							Image:           cr.Spec.DevfileIndexImage,
@@ -221,6 +215,16 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 			Name:  "REGISTRY_HEADLESS",
 			Value: "true",
 		})
+	}
+
+	// Enables podspec security context if storage is enabled
+	if cr.Spec.Storage.Enabled == nil || *cr.Spec.Storage.Enabled {
+		dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
+			RunAsNonRoot: &runAsNonRoot,
+			RunAsUser:    &runAsUser,
+			RunAsGroup:   &runAsGroup,
+			FSGroup:      &fsGroup,
+		}
 	}
 
 	// Set DevfileRegistry instance as the owner and controller


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

operator
registry

**What does does this PR do / why we need it**:

Adds the required pod level security context to allow actions to be performed on the OCI server needed for proper deployment, see devfile/api#1025 for full description about this problem.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1025

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the [registry operator documentation](https://github.com/devfile/devfile-web/tree/main/libs/docs/src/docs/no-version) need to updated with your changes?

**How to test changes / Special notes to the reviewer**:
