### PR TITLE
Storage enabled volume defaults to false

### DIFF
--- a/api/v1alpha1/devfileregistry_types.go
+++ b/api/v1alpha1/devfileregistry_types.go
@@ -74,7 +74,7 @@ type DevfileRegistrySpecContainer struct {
 // DevfileRegistrySpecStorage defines the desired state of the storage for the DevfileRegistry
 type DevfileRegistrySpecStorage struct {
 	// Instructs the operator to deploy the DevfileRegistry with persistent storage
-	// Enabled by default. Disabling is only recommended for development or test.
+	// Disabled by default.
 	// +optional
 	Enabled *bool `json:"enabled,omitempty"`
 

--- a/bundle/manifests/registry.devfile.io_devfileregistries.yaml
+++ b/bundle/manifests/registry.devfile.io_devfileregistries.yaml
@@ -106,8 +106,7 @@ spec:
                 properties:
                   enabled:
                     description: Instructs the operator to deploy the DevfileRegistry
-                      with persistent storage Enabled by default. Disabling is only
-                      recommended for development or test.
+                      with persistent storage Disabled by default.
                     type: boolean
                   ociRegistryImage:
                     description: Configures the size of the devfile registry's persistent

--- a/config/crd/bases/registry.devfile.io_devfileregistries.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistries.yaml
@@ -107,8 +107,7 @@ spec:
                 properties:
                   enabled:
                     description: Instructs the operator to deploy the DevfileRegistry
-                      with persistent storage Enabled by default. Disabling is only
-                      recommended for development or test.
+                      with persistent storage Disabled by default.
                     type: boolean
                   ociRegistryImage:
                     description: Configures the size of the devfile registry's persistent

--- a/pkg/registry/defaults.go
+++ b/pkg/registry/defaults.go
@@ -34,7 +34,7 @@ const (
 
 	// Defaults/constants for devfile registry storages
 	DefaultDevfileRegistryVolumeSize = "1Gi"
-	DevfileRegistryVolumeEnabled     = true
+	DevfileRegistryVolumeEnabled     = false
 	DevfileRegistryVolumeName        = "devfile-registry-storage"
 
 	DevfileRegistryTLSEnabled       = true
@@ -133,7 +133,7 @@ func GetDevfileRegistryVolumeSource(cr *registryv1alpha1.DevfileRegistry) corev1
 }
 
 // IsStorageEnabled returns true if storage.enabled is set in the DevfileRegistry CR
-// If it's not set, it returns true by default.
+// If it's not set, it returns false by default.
 func IsStorageEnabled(cr *registryv1alpha1.DevfileRegistry) bool {
 	if cr.Spec.Storage.Enabled != nil {
 		return *cr.Spec.Storage.Enabled

--- a/pkg/registry/defaults_test.go
+++ b/pkg/registry/defaults_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2022 Red Hat, Inc.
+Copyright 2020-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -107,11 +107,11 @@ func TestIsStorageEnabled(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "Case 3: Storage not set, default set to true",
+			name: "Case 3: Storage not set, default set to false",
 			cr: registryv1alpha1.DevfileRegistry{
 				Spec: registryv1alpha1.DevfileRegistrySpec{},
 			},
-			want: true,
+			want: false,
 		},
 	}
 	for _, tt := range tests {
@@ -168,18 +168,14 @@ func TestGetDevfileRegistryVolumeSource(t *testing.T) {
 			want: corev1.VolumeSource{},
 		},
 		{
-			name: "Case 3: Storage not set, default set to true",
+			name: "Case 3: Storage not set, default set to false",
 			cr: registryv1alpha1.DevfileRegistry{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: crName,
 				},
 				Spec: registryv1alpha1.DevfileRegistrySpec{},
 			},
-			want: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: PVCName(crName),
-				},
-			},
+			want: corev1.VolumeSource{},
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/registry/deployment.go
+++ b/pkg/registry/deployment.go
@@ -314,7 +314,7 @@ func GenerateDeployment(cr *registryv1alpha1.DevfileRegistry, scheme *runtime.Sc
 	}
 
 	// Enables podspec security context if storage is enabled
-	if cr.Spec.Storage.Enabled == nil || *cr.Spec.Storage.Enabled {
+	if IsStorageEnabled(cr) {
 		dep.Spec.Template.Spec.SecurityContext = &corev1.PodSecurityContext{
 			RunAsNonRoot: &runAsNonRoot,
 			RunAsUser:    &runAsUser,


### PR DESCRIPTION
**Please specify the area for this PR**

registry operator

**What does does this PR do / why we need it**:

Storage enabled volume property now defaults to false, OCI registry volume now uses `emptydir` by default. This change fixes permission issues for kubernetes deployments and is work towards proper OCP 4.12 support.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1029
part of devfile/api#1092

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the [registry operator documentation](https://github.com/devfile/devfile-web/tree/main/libs/docs/src/docs/no-version) need to updated with your changes?

**How to test changes / Special notes to the reviewer**:
