### PR TITLE
Add namespace webhook validation

### DIFF
--- a/api/v1alpha1/clusterdevfileregistrieslist_webhook.go
+++ b/api/v1alpha1/clusterdevfileregistrieslist_webhook.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Red Hat, Inc.
+Copyright 2022-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -70,8 +70,11 @@ func (r *ClusterDevfileRegistriesList) ValidateCreate() error {
 		return fmt.Errorf(multiCRError)
 	}
 
-	return validateURLs(r.Spec.DevfileRegistries)
+	if err := validateURLs(r.Spec.DevfileRegistries); err != nil {
+		return err
+	}
 
+	return IsNamespaceValid(r.Namespace)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1alpha1/clusterdevfileregistrieslist_webhook.go
+++ b/api/v1alpha1/clusterdevfileregistrieslist_webhook.go
@@ -42,7 +42,7 @@ func (r *ClusterDevfileRegistriesList) SetupWebhookWithManager(mgr ctrl.Manager)
 
 var _ webhook.Defaulter = &ClusterDevfileRegistriesList{}
 
-const multiCRError = "A ClusterDevfileRegistriesList instance already exists. Only one instance can exist in a cluster"
+const multiCRError = "a ClusterDevfileRegistriesList instance already exists, only one instance can exist in a cluster"
 
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *ClusterDevfileRegistriesList) Default() {
@@ -63,7 +63,7 @@ func (r *ClusterDevfileRegistriesList) ValidateCreate() error {
 	}
 
 	if err := kubeClient.List(context.TODO(), clusterDevfileRegistriesList, listOpts...); err != nil {
-		return fmt.Errorf("Error listing clusterDevfileRegistriesList custom resources: %v", err)
+		return fmt.Errorf("error listing clusterDevfileRegistriesList custom resources: %v", err)
 	}
 
 	if len(clusterDevfileRegistriesList.Items) == 1 {

--- a/api/v1alpha1/clusterdevfileregistrieslist_webhook_test.go
+++ b/api/v1alpha1/clusterdevfileregistrieslist_webhook_test.go
@@ -72,7 +72,7 @@ var _ = Describe("ClusterDevfileRegistriesList validation webhook", func() {
 		})
 	})
 
-	Context("Create a second ClusterDevfileRegistry CR with valid values in same namespace", func() {
+	Context("Create a second ClusterDevfileRegistriesList CR with valid values in same namespace", func() {
 		It("Should fail to create a new CR and return an error message", func() {
 			ctx := context.Background()
 			err := k8sClient.Create(ctx, getClusterDevfileRegistriesListCR(devfileRegistriesListName+"2", devfileRegistriesNamespace,
@@ -81,7 +81,7 @@ var _ = Describe("ClusterDevfileRegistriesList validation webhook", func() {
 		})
 	})
 
-	Context("Create a second ClusterDevfileRegistry CR with valid fields in a different namespace", func() {
+	Context("Create a second ClusterDevfileRegistriesList CR with valid fields in a different namespace", func() {
 		It("Should fail to create a new CR and return an error message", func() {
 			ctx := context.Background()
 			err := k8sClient.Create(ctx, getClusterDevfileRegistriesListCR(devfileRegistriesListName, testNs.Name,

--- a/api/v1alpha1/clusterdevfileregistrieslist_webhook_test.go
+++ b/api/v1alpha1/clusterdevfileregistrieslist_webhook_test.go
@@ -1,6 +1,6 @@
 //
 //
-// Copyright 2022 Red Hat, Inc.
+// Copyright 2022-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,10 +30,18 @@ import (
 var _ = Describe("ClusterDevfileRegistriesList validation webhook", func() {
 
 	Context("Create ClusterDevfileRegistriesList CR with valid values", func() {
-		It("Should create a new CR in the default namespace", func() {
+		It("Should create a new CR in a non-default namespace called 'main'", func() {
 			ctx := context.Background()
 			Expect(k8sClient.Create(ctx, getClusterDevfileRegistriesListCR(devfileRegistriesListName, devfileRegistriesNamespace,
 				devfileStagingRegistryName, devfileStagingRegistryURL))).Should(Succeed())
+		})
+	})
+
+	Context("Create ClusterDevfileRegistriesList CR with valid values", func() {
+		It("Should fail to create a new CR in the default namespace", func() {
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, getClusterDevfileRegistriesListCR("default-namespace-list", "default",
+				devfileStagingRegistryName, devfileStagingRegistryURL))).ShouldNot(Succeed())
 		})
 	})
 

--- a/api/v1alpha1/devfileregistrieslist_webhook.go
+++ b/api/v1alpha1/devfileregistrieslist_webhook.go
@@ -64,11 +64,11 @@ func (r *DevfileRegistriesList) ValidateCreate() error {
 	}
 
 	if err := kubeClient.List(context.TODO(), devfileRegistriesList, listOpts...); err != nil {
-		return fmt.Errorf("Error listing devfileRegistriesList custom resources: %v", err)
+		return fmt.Errorf("error listing devfileRegistriesList custom resources: %v", err)
 	}
 
 	if len(devfileRegistriesList.Items) == 1 {
-		return fmt.Errorf("A DevfileRegistriesList instance already exists. Only one instance can exist on a namespace")
+		return fmt.Errorf("a DevfileRegistriesList instance already exists. Only one instance can exist on a namespace")
 	}
 
 	if err := validateURLs(r.Spec.DevfileRegistries); err != nil {

--- a/api/v1alpha1/devfileregistrieslist_webhook.go
+++ b/api/v1alpha1/devfileregistrieslist_webhook.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Red Hat, Inc.
+Copyright 2022-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -71,7 +71,11 @@ func (r *DevfileRegistriesList) ValidateCreate() error {
 		return fmt.Errorf("A DevfileRegistriesList instance already exists. Only one instance can exist on a namespace")
 	}
 
-	return validateURLs(r.Spec.DevfileRegistries)
+	if err := validateURLs(r.Spec.DevfileRegistries); err != nil {
+		return err
+	}
+
+	return IsNamespaceValid(r.Namespace)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1alpha1/devfileregistrieslist_webhook_test.go
+++ b/api/v1alpha1/devfileregistrieslist_webhook_test.go
@@ -72,7 +72,7 @@ var _ = Describe("DevfileRegistriesList validation webhook", func() {
 		})
 	})
 
-	Context("Create a second DevfileRegistry CR with valid values in same namespace", func() {
+	Context("Create a second DevfileRegistriesList CR with valid values in same namespace", func() {
 		It("Should fail to create a new CR and return an error message", func() {
 			ctx := context.Background()
 			Expect(k8sClient.Create(ctx, getDevfileRegistriesListCR(devfileRegistriesListName+"2", devfileRegistriesNamespace,
@@ -80,7 +80,7 @@ var _ = Describe("DevfileRegistriesList validation webhook", func() {
 		})
 	})
 
-	Context("Create a second DevfileRegistry CR with valid fields in a different namespace", func() {
+	Context("Create a second DevfileRegistriesList CR with valid fields in a different namespace", func() {
 		It("Should fail to create a new CR and return an error message", func() {
 			ctx := context.Background()
 			Expect(k8sClient.Create(ctx, getDevfileRegistriesListCR(devfileRegistriesListName, testNs.Name,

--- a/api/v1alpha1/devfileregistrieslist_webhook_test.go
+++ b/api/v1alpha1/devfileregistrieslist_webhook_test.go
@@ -1,6 +1,6 @@
 //
 //
-// Copyright 2022 Red Hat, Inc.
+// Copyright 2022-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -30,10 +30,18 @@ import (
 var _ = Describe("DevfileRegistriesList validation webhook", func() {
 
 	Context("Create DevfileRegistriesList CR with valid values", func() {
-		It("Should create a new CR in the default namespace", func() {
+		It("Should create a new CR in a non-default namespace called 'main'", func() {
 			ctx := context.Background()
 			Expect(k8sClient.Create(ctx, getDevfileRegistriesListCR(devfileRegistriesListName, devfileRegistriesNamespace,
 				devfileStagingRegistryName, devfileStagingRegistryURL))).Should(Succeed())
+		})
+	})
+
+	Context("Create DevfileRegistriesList CR in forbidden default namespace", func() {
+		It("Should fail to create a new CR in the default namespace", func() {
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, getDevfileRegistriesListCR("default-namespace-list", "default",
+				devfileStagingRegistryName, devfileStagingRegistryURL))).ShouldNot(Succeed())
 		})
 	})
 

--- a/api/v1alpha1/devfileregistry_webhook.go
+++ b/api/v1alpha1/devfileregistry_webhook.go
@@ -50,25 +50,13 @@ var _ webhook.Validator = &DevfileRegistry{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *DevfileRegistry) ValidateCreate() error {
 	devfileregistrylog.Info("validate create", "name", r.Name)
-
 	return IsNamespaceValid(r.Namespace)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
 func (r *DevfileRegistry) ValidateUpdate(old runtime.Object) error {
 	devfileregistrylog.Info("validate update", "name", r.Name)
-
-	// Validate if namespace is valid
-	if err := IsNamespaceValid(r.Namespace); err != nil {
-		return err
-	}
-
-	//re-validate the entire list to ensure existing URL has not gone stale
-	if r.Spec.TLS.Enabled != nil {
-		return IsRegistryValid(*r.Spec.TLS.Enabled, r.Status.URL)
-	} else {
-		return IsRegistryValid(true, r.Status.URL)
-	}
+	return nil
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type

--- a/api/v1alpha1/devfileregistry_webhook.go
+++ b/api/v1alpha1/devfileregistry_webhook.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var (
+	devfileregistrylog = logf.Log.WithName("devfileregistry-resource")
+)
+
+func (r *DevfileRegistry) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/mutate-registry-devfile-io-v1alpha1-devfileregistry,mutating=true,failurePolicy=fail,sideEffects=None,groups=registry.devfile.io,resources=devfileregistries,verbs=create;update,versions=v1alpha1,name=mdevfileregistry.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Defaulter = &DevfileRegistry{}
+
+// Default implements webhook.Defaulter so a webhook will be registered for the type
+func (r *DevfileRegistry) Default() {
+	devfileregistrylog.Info("default", "name", r.Name)
+}
+
+//+kubebuilder:webhook:path=/validate-registry-devfile-io-v1alpha1-devfileregistry,mutating=false,failurePolicy=fail,sideEffects=None,groups=registry.devfile.io,resources=devfileregistries,verbs=create;update,versions=v1alpha1,name=vdevfileregistry.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &DevfileRegistry{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *DevfileRegistry) ValidateCreate() error {
+	devfileregistrylog.Info("validate create", "name", r.Name)
+
+	return IsNamespaceValid(r.Namespace)
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *DevfileRegistry) ValidateUpdate(old runtime.Object) error {
+	devfileregistrylog.Info("validate update", "name", r.Name)
+
+	// Validate if namespace is valid
+	if err := IsNamespaceValid(r.Namespace); err != nil {
+		return err
+	}
+
+	//re-validate the entire list to ensure existing URL has not gone stale
+	if r.Spec.TLS.Enabled != nil {
+		return IsRegistryValid(*r.Spec.TLS.Enabled, r.Status.URL)
+	} else {
+		return IsRegistryValid(true, r.Status.URL)
+	}
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *DevfileRegistry) ValidateDelete() error {
+	devfileregistrylog.Info("validate delete", "name", r.Name)
+	return nil
+}

--- a/api/v1alpha1/devfileregistry_webhook_test.go
+++ b/api/v1alpha1/devfileregistry_webhook_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"context"
+
+	. "github.com/devfile/registry-operator/pkg/test"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("DevfileRegistry validation webhook", func() {
+	Context("Create DevfileRegistry CR with valid values", func() {
+		It("Should create a new CR in a non-default namespace called 'main'", func() {
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, getDevfileRegistryCR("devfileregistry", devfileRegistriesNamespace))).Should(Succeed())
+		})
+	})
+
+	Context("Create DevfileRegistry CR in forbidden default namespace", func() {
+		It("Should fail to create a new CR in the default namespace", func() {
+			ctx := context.Background()
+			Expect(k8sClient.Create(ctx, getDevfileRegistryCR("default-devfileregistry", "default"))).ShouldNot(Succeed())
+		})
+	})
+})
+
+func getDevfileRegistryCR(name string, namespace string) *DevfileRegistry {
+	return &DevfileRegistry{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ApiVersion,
+			Kind:       "DevfileRegistry",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}

--- a/api/v1alpha1/validate.go
+++ b/api/v1alpha1/validate.go
@@ -25,9 +25,10 @@ import (
 )
 
 const (
-	dupRegName      = "Duplicate registry name %s in registries list.  Ensure name is unique \n"
-	dupURLName      = "Duplicate registry URL %s in registries list.  Ensure URL is unique \n"
-	InvalidRegistry = "Devfile %s Registry is either invalid or unavailable, unable to add to the DevfileRegistryService list. Ensure you provide a valid Devfile Registry URL \n"
+	dupRegName       = "duplicate registry name %s in registries list.  Ensure name is unique"
+	dupURLName       = "duplicate registry URL %s in registries list.  Ensure URL is unique"
+	InvalidRegistry  = "devfile %s Registry is either invalid or unavailable, unable to add to the DevfileRegistryService list. Ensure you provide a valid Devfile Registry URL"
+	InvalidNamespace = "the namespace 'default' is forbidden for the devfile registry deployment. Retry the deployment using a non-default namespace"
 )
 
 func validateURLs(devfileRegistries []DevfileRegistryService) (errors error) {
@@ -92,10 +93,7 @@ func IsRegistryValid(skipTLSVerify bool, url string) error {
 // is valid.
 func IsNamespaceValid(namespace string) error {
 	if namespace == "default" {
-		return fmt.Errorf("%s. %s",
-			"The namespace 'default' is forbidden for the devfile registry deployment",
-			"Retry the deployment using a non-default namespace",
-		)
+		return fmt.Errorf("%s", InvalidNamespace)
 	}
 
 	return nil

--- a/api/v1alpha1/validate.go
+++ b/api/v1alpha1/validate.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Red Hat, Inc.
+Copyright 2022-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -92,7 +92,10 @@ func IsRegistryValid(skipTLSVerify bool, url string) error {
 // is valid.
 func IsNamespaceValid(namespace string) error {
 	if namespace == "default" {
-		return fmt.Errorf("devfile registry deployment namespace should never be 'default'.")
+		return fmt.Errorf("%s. %s",
+			"The namespace 'default' is forbidden for the devfile registry deployment",
+			"Retry the deployment using a non-default namespace",
+		)
 	}
 
 	return nil

--- a/api/v1alpha1/validate.go
+++ b/api/v1alpha1/validate.go
@@ -87,3 +87,13 @@ func IsRegistryValid(skipTLSVerify bool, url string) error {
 
 	return nil
 }
+
+// IsNamespaceValid determines if given namespace for deployment
+// is valid.
+func IsNamespaceValid(namespace string) error {
+	if namespace == "default" {
+		return fmt.Errorf("devfile registry deployment namespace should never be 'default'.")
+	}
+
+	return nil
+}

--- a/api/v1alpha1/validate_test.go
+++ b/api/v1alpha1/validate_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Red Hat, Inc.
+Copyright 2022-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -102,6 +102,36 @@ func TestDevfileRegistriesValidateURL(t *testing.T) {
 				}
 			} else {
 				assert.Equal(t, nil, err, "Error should be nil")
+			}
+		})
+	}
+}
+
+func TestIsNamespaceValid(t *testing.T) {
+	tests := []struct {
+		name      string
+		namespace string
+		wantErr   string
+	}{
+		{
+			name:      "Registry deployment to non-default namespace",
+			namespace: "test",
+		},
+		{
+			name:      "Registry deployment to default namespace",
+			namespace: "default",
+			wantErr:   InvalidNamespace,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := IsNamespaceValid(tt.namespace); err != nil && tt.wantErr != "" {
+				assert.Equal(t, len(tt.wantErr), len(err.Error()), fmt.Sprintf("Errors do not match = %v, want %v", err, tt.wantErr))
+			} else if err != nil && tt.wantErr == "" {
+				assert.Fail(t, "Error should be nil")
+			} else if err == nil && tt.wantErr != "" {
+				assert.Fail(t, "Error should not be nil")
 			}
 		})
 	}

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -128,6 +128,9 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	err = (&DevfileRegistry{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	err = (&DevfileRegistriesList{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2022 Red Hat, Inc.
+Copyright 2020-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -54,8 +54,8 @@ var ctx context.Context
 var cancel context.CancelFunc
 
 const (
-	devfileRegistriesListName  = "default-namespace-list"
-	devfileRegistriesNamespace = "default"
+	devfileRegistriesListName  = "main-namespace-list"
+	devfileRegistriesNamespace = "main"
 	devfileStagingRegistryName = "StagingRegistry"
 	devfileStagingRegistryURL  = "https://registry.stage.devfile.io"
 	localRegistryName          = "localRegistry"

--- a/api/v1alpha1/webhook_suite_test.go
+++ b/api/v1alpha1/webhook_suite_test.go
@@ -61,11 +61,18 @@ const (
 	localRegistryName          = "localRegistry"
 )
 
-var testNs = &corev1.Namespace{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: "test",
-	},
-}
+var (
+	devfileRegistriesNs = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: devfileRegistriesNamespace,
+		},
+	}
+	testNs = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -104,6 +111,8 @@ var _ = BeforeSuite(func() {
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+	//create devfileregistries namespace
+	Expect(k8sClient.Create(ctx, devfileRegistriesNs)).Should(Succeed())
 	//create test namespace
 	Expect(k8sClient.Create(ctx, testNs)).Should(Succeed())
 
@@ -149,6 +158,8 @@ var _ = BeforeSuite(func() {
 }, 60)
 
 var _ = AfterSuite(func() {
+	// delete the devfileregistries namespace
+	Expect(k8sClient.Delete(ctx, devfileRegistriesNs)).Should(Succeed())
 	// delete the test namespace
 	Expect(k8sClient.Delete(ctx, testNs)).Should(Succeed())
 	cancel()

--- a/bundle/manifests/registry-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/registry-operator.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-03-23T21:23:04Z"
+    createdAt: "2023-04-05T22:05:49Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: registry-operator.v0.0.1
@@ -412,6 +412,26 @@ spec:
     containerPort: 443
     deploymentName: registry-operator-controller-manager
     failurePolicy: Fail
+    generateName: mdevfileregistry.kb.io
+    rules:
+    - apiGroups:
+      - registry.devfile.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - devfileregistries
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /mutate-registry-devfile-io-v1alpha1-devfileregistry
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: registry-operator-controller-manager
+    failurePolicy: Fail
     generateName: vclusterdevfileregistrieslist.kb.io
     rules:
     - apiGroups:
@@ -447,3 +467,23 @@ spec:
     targetPort: 9443
     type: ValidatingAdmissionWebhook
     webhookPath: /validate-registry-devfile-io-v1alpha1-devfileregistrieslist
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: registry-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vdevfileregistry.kb.io
+    rules:
+    - apiGroups:
+      - registry.devfile.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - devfileregistries
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-registry-devfile-io-v1alpha1-devfileregistry

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -45,6 +45,26 @@ webhooks:
     resources:
     - devfileregistrieslists
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /mutate-registry-devfile-io-v1alpha1-devfileregistry
+  failurePolicy: Fail
+  name: mdevfileregistry.kb.io
+  rules:
+  - apiGroups:
+    - registry.devfile.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - devfileregistries
+  sideEffects: None
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -91,4 +111,24 @@ webhooks:
     - UPDATE
     resources:
     - devfileregistrieslists
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-registry-devfile-io-v1alpha1-devfileregistry
+  failurePolicy: Fail
+  name: vdevfileregistry.kb.io
+  rules:
+  - apiGroups:
+    - registry.devfile.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - devfileregistries
   sideEffects: None

--- a/main.go
+++ b/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020-2022 Red Hat, Inc.
+Copyright 2020-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -105,6 +105,10 @@ func main() {
 
 	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
 		setupLog.Info("setting up webhooks")
+		if err = (&registryv1alpha1.DevfileRegistry{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "DevfileRegistry")
+			os.Exit(1)
+		}
 		if err = (&registryv1alpha1.DevfileRegistriesList{}).SetupWebhookWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create webhook", "webhook", "DevfileRegistriesList")
 			os.Exit(1)


### PR DESCRIPTION
**Please specify the area for this PR**

registry operator

**What does does this PR do / why we need it**:

Adds namespace validation to webhooks for `devfileregistry`, `devfileregistries`, and `clusterdevfileregistrieslist` to prevent deployment to the default namespace.

**Which issue(s) this PR fixes**:

Fixes #?

part of devfile/api#1092

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the [registry operator documentation](https://github.com/devfile/devfile-web/tree/main/libs/docs/src/docs/no-version) need to updated with your changes?

**How to test changes / Special notes to the reviewer**:
