### PR TITLE
Correct source path for local build rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,11 @@ test-integration:
 
 .PHONY: build manager
 manager: manifests generate fmt vet ## Build manager binary.
-	go build -o $(LOCALBIN)/manager ./cmd/main.go
+	go build -o $(LOCALBIN)/manager ./main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
+	$(LOCALBIN)/manager
 
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.


### PR DESCRIPTION
**Please specify the area for this PR**

registry operator

**What does does this PR do / why we need it**:

Fixes incorrect source paths for local build rules:
- [Makefile#L121](https://github.com/devfile/registry-operator/blob/b13d6d8c19a2c7af0f5e250e912c95a7bbc643ae/Makefile#L121)
- [Makefile#L125](https://github.com/devfile/registry-operator/blob/b13d6d8c19a2c7af0f5e250e912c95a7bbc643ae/Makefile#L125)

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1329

**PR acceptance criteria**:

- [X] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [X] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
