### PR TITLE
Implement Podman scripts for Registry-Operator Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,17 +24,18 @@ You can tag Devfile Registry related issues with the `/area registry` text in yo
 3. Open the folder in the IDE of your choice (VS Code with Go extension, or GoLand is recommended)
 
 #### Build and Run the Operator
+The Makefile currently supports both Docker and Podman. To run the proper command replace `<engine>` with either `podman` or `docker` depending on your container engine.
 1. Log in to an OpenShift or Kubernetes cluster
 
 2. Run `export IMG=<operator-image>` where `<operator-image>` is the image repository to where you would like to push the image (e.g. `quay.io/user/registry-operator:latest`).
 
-3. Run `make docker-build` to build the devfile registry operator.
+3. Run `make <engine>-build` to build the devfile registry operator.
 
-4. Run `make docker-push` to push the devfile registry operator image.
+4. Run `make <engine>-push` to push the devfile registry operator image.
 
-5. (Optional, **docker only**) Run `make docker-buildx` to build and push the devfile registry operator multi-architecture image
+5. (Optional, **docker only**) Run `make docker-buildx` to build and push the devfile registry operator multi-architecture image.
 
-6. Run `make install-cert` to install the cert-manager.
+6. Run `make install-cert` to install the cert-manager. (Allow time for these services to spin up before moving on to step 7 & 8).
 
 7. Run `make install` to install the CRDs.
 

--- a/Makefile
+++ b/Makefile
@@ -195,6 +195,17 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 	- docker buildx rm registry-operator-builder
 	rm Dockerfile.cross
 
+# Build the podman image
+.PHONY: podman-build
+podman-build:
+	podman build . -t ${IMG} --build-arg ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}
+
+# Push the podman image
+.PHONY: podman-push
+podman-push:
+	podman push ${IMG}
+
+
 .PHONY: install-cert
 install-cert: ## Install cert manager for webhooks
 	$(K8S_CLI) apply -f https://github.com/cert-manager/cert-manager/releases/download/$(CERT_MANAGER_VERSION)/cert-manager.yaml

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ Some of the rules supported by the makefile:
 | kustomize | install the kustomize tool, used by other commands |
 | docker-build | build registry operator docker image |
 | docker-push | push registry operator docker image |
-| docker-buildx | build & push registry operator docker image for all supported architectures \(**does not work with podman**\) |
+| docker-buildx | build & push registry operator docker image for all supported architectures |
+| podman-build | build registry operator podman image |
+| podman-push | push registry operator podman image |
 | deploy | deploy operator to cluster |
 | undeploy | undeploy operator from cluster |
 | install | create the devfile registry CRDs on the cluster |
@@ -101,7 +103,7 @@ define the environment variable `K8S_CLI` with the command you prefer to use.
 
 By default, the tests will use the default image for the operator, `quay.io/devfile/registry-operator:next`.
 
-You can use `make docker-build` to build your own image, `make docker-push` to publish it. Then, to use your own image, run:
+You can use `make <engine>-build` to build your own image, `make <engine>-push` to publish it - Replace `<engine>` with `podman` or `docker`. Then, to use your own image, run:
 
 ```
 IMG=<your-operator-image> make test-integration

--- a/README.md
+++ b/README.md
@@ -71,11 +71,11 @@ Some of the rules supported by the makefile:
 |---|---|
 | controller-gen | install the controller-gen tool, used by other commands |
 | kustomize | install the kustomize tool, used by other commands |
-| docker-build | build registry operator docker image |
-| docker-push | push registry operator docker image |
+| docker-build | build registry operator container image using docker |
+| docker-push | push registry operator container image using docker |
 | docker-buildx | build & push registry operator docker image for all supported architectures |
-| podman-build | build registry operator podman image |
-| podman-push | push registry operator podman image |
+| podman-build | build registry operator container image using podman |
+| podman-push | push registry operator container image using podman |
 | deploy | deploy operator to cluster |
 | undeploy | undeploy operator from cluster |
 | install | create the devfile registry CRDs on the cluster |


### PR DESCRIPTION
**Please specify the area for this PR**
Registry-Operator

**What does does this PR do / why we need it**:
Implements podman script support for the Registry-Operator build and push commands

**Which issue(s) this PR fixes**:

Fixes #?
https://github.com/devfile/api/issues/1340

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation
- [x] Does the registry operator documentation need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
Run the new commands via CLI to build and push images created with podman instead of docker