### PR TITLE
[Devtools Week] Multi-platform support for build binary and container images

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,47 @@ The Makefile currently supports both Docker and Podman. To run the proper comman
 
 By default, http/2 on the webhook server is disabled due to [CVE-2023-44487](https://github.com/advisories/GHSA-qppj-fm5r-hxr3).
 
-If you want to enable http/2 for the webhook server, build with `ENABLE_WEBHOOK_HTTP2=true make docker-build` or with 
+If you want to enable http/2 for the webhook server, build with `ENABLE_WEBHOOK_HTTP2=true make <engine>-build` or with 
 `ENABLE_WEBHOOK_HTTP2=true make run` if running locally.
+
+##### Using other platforms
+
+If you need to target another platform for container builds, such as Apple silicon, you can use `TARGET_ARCH=<architecture> make <engine>-build`.
+
+For example, to target container build to `arm64` run the following:
+
+```sh
+TARGET_ARCH=arm64 make <engine>-build
+```
+
+**Note:** Container builds only use `linux` as the operating system as local cluster runtime environments, such as `minikube` environments, run under Linux virtual machines for other operating systems. For example, _Apple silicon_ would just use the `arm64` container build.
+
+For local builds, you can also set the target operating system:
+
+**Apple silicon**
+
+```sh
+export TARGET_OS=darwin
+export TARGET_ARCH=arm64
+make manager
+```
+
+**Linux ARM**
+
+```sh
+export TARGET_ARCH=arm64
+make manager
+```
+
+**Windows**
+
+```sh
+export TARGET_OS=windows
+export TARGET_ARCH=amd64
+make manager
+```
+
+By default, `amd64` is used for the target architecture and `linux` is used for the target operating system.
 
 ### Testing your Changes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ENV ENABLE_WEBHOOK_HTTP2=${ENABLE_WEBHOOK_HTTP2}
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot
+FROM gcr.io/distroless/static:nonroot-${TARGETARCH}
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 
 # Build the manager binary
 FROM golang:1.19 as builder
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,8 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
-## Architechure
+## Target platform
+TARGET_OS ?= linux # `make manager` only
 TARGET_ARCH ?= amd64
 
 ##@ Development
@@ -122,7 +123,7 @@ test-integration:
 
 .PHONY: build manager
 manager: manifests generate fmt vet ## Build manager binary.
-	go build -o $(LOCALBIN)/manager ./main.go
+	GOOS=${TARGET_OS} GOARCH=${TARGET_ARCH} go build -o $(LOCALBIN)/manager ./main.go
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 
+## Architechure
+TARGET_ARCH ?= amd64
+
 ##@ Development
 
 .PHONY: test
@@ -171,7 +174,8 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 # Build the docker image
 .PHONY: docker-build
 docker-build:
-	docker build . -t ${IMG} --build-arg ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS} \
+	docker build . -t ${IMG} --build-arg TARGETARCH=${TARGET_ARCH} \
+--build-arg ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS} \
 --build-arg ENABLE_WEBHOOK_HTTP2=${ENABLE_WEBHOOK_HTTP2}
 
 # Push the docker image
@@ -200,7 +204,9 @@ docker-buildx: test ## Build and push docker image for the manager for cross-pla
 # Build the podman image
 .PHONY: podman-build
 podman-build:
-	podman build . -t ${IMG} --build-arg ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}
+	podman build . -t ${IMG} --build-arg TARGETARCH=${TARGET_ARCH} \
+--build-arg ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS} \
+--build-arg ENABLE_WEBHOOK_HTTP2=${ENABLE_WEBHOOK_HTTP2}
 
 # Push the podman image
 .PHONY: podman-push

--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ The repository contains a Makefile; building and deploying can be configured via
 |variable|purpose|default value|
 |---|---|---|
 | `IMG` | Image used for controller (run makefile, if `IMG` is updated) | `quay.io/devfile/registry-operator:next` |
+| `BUNDLE_IMG` | Image used for bundle OLM package | `quay.io/devfile/registry-operator-bundle:<latest_version>` |
+| `CERT_MANAGER_VERSION` | Version of `cert-manager` installed using `make install-cert` | `v1.11.0` |
+| `ENABLE_WEBHOOKS` | If `false`, disables operator webhooks | `true` |
+| `ENABLE_WEBHOOK_HTTP2` | Overrides webhook HTTP server deployment to use http/2 if set to `true`, **not recommended** | `false` |
+| `BUNDLE_CHANNELS` | Sets the list channel(s) include bundle build under | `alpha` |
+| `BUNDLE_DEFAULT_CHANNEL` | Sets the default channel to use when installing the bundle | |
+| `ENVTEST_K8S_VERSION` | Version of k8s to use for the test environment | `1.26` (current) |
+| `CONTROLLER_TOOLS_VERSION` | Version of the controller tools | `v0.9.2` |
+| `KUSTOMIZE_VERSION` | Version of kustomize | `v3.8.7` | 
+| `GOBIN` | Path to install Go binaries to | `${GOPATH}/bin` |
+| `K8S_CLI` | Path to CLI tool to use with the target cluster environment, `kubectl` or `oc` | Either `oc` or `kubectl` if installed in that order |
+| `OPERATOR_SDK_CLI` | CLI path to `operator-sdk` tool | `operator-sdk` |
+| `SHELL` | Active shell to use with make | `/usr/bin/env bash -o pipefail` |
+| `LOCALBIN` | Path to place project binaries | `./bin` |
+| `KUSTOMIZE` | Path to target `kustomize` binary | `${LOCALBIN}/kustomize` |
+| `CONTROLLER_GEN` | Path to target `controller-gen` binary | `${LOCALBIN}/controller-gen` |
+| `ENVTEST` | Path to target `setup-envtest` binary | `${LOCALBIN}/setup-envtest` |
+| `TARGET_ARCH` | Target architecture for operator manager builds, possible values: `amd64`, `arm64`, `s390x`, `ppc64le` | `amd64` |
+| `TARGET_OS` | Target operating system for operator manager build, **only for `make manager`** | `linux` |
+| `PLATFORMS` | Target architecture(s) for `make docker-buildx` | All supported: `linux/arm64,linux/amd64,linux/s390x,linux/ppc64le` |
+| `KUSTOMIZE_INSTALL_SCRIPT` | URL of kustomize installation script, see [kustomize installation instructions](https://kubectl.docs.kubernetes.io/installation/kustomize/binaries/) | `https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh` |
 
 Some of the rules supported by the makefile:
 


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:

Adds support for building the registry operator binaries and container images to target other platforms and fixes missing pieces to properly run `make docker-buildx`.

**Additional changes**
- Updated environment variable table under `README.md`
- Includes build arg in `podman-build` make rule for enabling http/2 for webhook server
- Corrects `make docker-build` to `make <engine>-build` under instructions on enabling http/2 for webhook server

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1383

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [x] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [X] Does the registry operator documentation need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
