### PR TITLE
Remove CHANGELOG section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,6 @@ The Devfile Registry operator manages the lifecycle of the following custom reso
 
 Issue tracking repo: https://github.com/devfile/api with label area/registry
 
-## Changelog
-
-Access the [CHANGELOG.md](CHANGELOG.md) here.
-
 ## Requirements
 
 Deployment cluster must meet one of the following criteria:


### PR DESCRIPTION
**Please specify the area for this PR**

documentation

**What does does this PR do / why we need it**:

Since `CHANGELOG.md` no longer exists in favour of using release notes, the section for it should be removed.

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [x] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [x] Does the registry operator documentation need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
