### PR TITLE
registry-operator release automation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -290,7 +290,7 @@ gosec:
 	gosec -no-fail -fmt=sarif -out=gosec.sarif -exclude-dir pkg/test -exclude-dir tests ./...
 
 ### Release
-# RUN: make release new-version=x.x.x
+# RUN: make release NEW_VERSION=x.x.x
 .PHONY: 
 release:
-	sh make-release.sh ${new-version}
+	sh make-release.sh ${NEW_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -288,3 +288,9 @@ gosec:
 	# Run this command to install gosec, if not installed:
 	# go install github.com/securego/gosec/v2/cmd/gosec@v2.14.0
 	gosec -no-fail -fmt=sarif -out=gosec.sarif -exclude-dir pkg/test -exclude-dir tests ./...
+
+### Release
+# RUN: make release new-version=x.x.x
+.PHONY: 
+release:
+	sh make-release.sh ${new-version}

--- a/Makefile
+++ b/Makefile
@@ -262,11 +262,14 @@ $(ENVTEST): $(LOCALBIN)
 	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) GOFLAGS="" go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
 
 # Generate bundle manifests and metadata, then validate generated files.
+## sh replace-alm-examples.sh is there to fix an issue with Kustomize removing List items
+## More information can be found here: https://github.com/kubernetes-sigs/kustomize/issues/5042
 .PHONY: bundle
 bundle: manifests
 	$(OPERATOR_SDK_CLI) generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK_CLI) generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
+	sh replace-alm-examples.sh
 	$(OPERATOR_SDK_CLI) bundle validate ./bundle
 
 # Build the bundle image.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Releases are available on [GitHub](https://github.com/devfile/registry-operator/
 
 For more updates on releases, please join our [communication channels](https://devfile.io/docs/2.2.2/community#getting-involved).
 
+## Preparing Releases
+A script has been created to make the release process more efficient. This script takes care of all changes to version numbers in all necessary files. Additionally this script opens the initial PR to devfile/registry-operator. The release engineer will be responsible for running this script with the instructions below.
+
+1. Navigate to main branch of your forked registry-operator repository.
+2. Run `make release new-version=x.x.x` where x.x.x is the version you are trying to cut.
+3. Edit the PR opened by the script on devfile/registry-operator to include a proper description.
+
 ## Issue Tracking
 
 Issue tracking repo: https://github.com/devfile/api with label area/registry

--- a/README.md
+++ b/README.md
@@ -23,13 +23,6 @@ Releases are available on [GitHub](https://github.com/devfile/registry-operator/
 
 For more updates on releases, please join our [communication channels](https://devfile.io/docs/2.2.2/community#getting-involved).
 
-## Preparing Releases
-A script has been created to make the release process more efficient. This script takes care of all changes to version numbers in all necessary files. Additionally this script opens the initial PR to devfile/registry-operator. The release engineer will be responsible for running this script with the instructions below.
-
-1. Navigate to main branch of your forked registry-operator repository.
-2. Run `make release new-version=x.x.x` where x.x.x is the version you are trying to cut.
-3. Edit the PR opened by the script on devfile/registry-operator to include a proper description.
-
 ## Issue Tracking
 
 Issue tracking repo: https://github.com/devfile/api with label area/registry
@@ -104,6 +97,7 @@ The repository contains a Makefile; building and deploying can be configured via
 | `TARGET_OS` | Target operating system for operator manager build, **only for `make manager`** | `linux` |
 | `PLATFORMS` | Target architecture(s) for `make docker-buildx` | All supported: `linux/arm64,linux/amd64,linux/s390x,linux/ppc64le` |
 | `KUSTOMIZE_INSTALL_SCRIPT` | URL of kustomize installation script, see [kustomize installation instructions](https://kubectl.docs.kubernetes.io/installation/kustomize/binaries/) | `https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh` |
+| `NEW_VERSION` | Release version being cut | |
 
 Some of the rules supported by the makefile:
 
@@ -131,6 +125,7 @@ Some of the rules supported by the makefile:
 | fmt_license | Ensure license header is set on all files |
 | vet | Check suspicious constructs into code |
 | gosec | Check for security problems in non-test source files |
+| release | Starts the process for cutting a new release |
 
 To see all rules supported by the makefile, run `make help`
 

--- a/make-release.sh
+++ b/make-release.sh
@@ -117,7 +117,7 @@ commitChanges() {
 # with the name release-vX
 ## This func will be used when we have a new major release and there is no branch in the upstream repo
 createNewReleaseBranch(){
-  git checkout -b "${RELEASE_BRANCH}" "${RELEASE_UPSTREAM_NAME}"/main
+  git checkout -b "${RELEASE_BRANCH}" main
   git push "${RELEASE_UPSTREAM_NAME}" "${RELEASE_BRANCH}"
   #hub sync -- this supposedly will create that branch in upstream
 }
@@ -127,7 +127,7 @@ verifyReleaseBranch() {
       echo "Branch $RELEASE_BRANCH exists in the upstream repository."
   else
       echo "Branch $RELEASE_BRANCH does not exist in the upstream repository."
-      #createNewReleaseBranch
+      createNewReleaseBranch
   
   fi
 }

--- a/make-release.sh
+++ b/make-release.sh
@@ -134,7 +134,7 @@ verifyReleaseBranch() {
 
 createPullRequest(){
   echo "[INFO] Creating a PR"
-  hub pull-request --base ${RELEASE_UPSTREAM_NAME}:${RELEASE_BRANCH} --head ${SCHEMA_VERSION} -m "$1"
+  hub pull-request --base jdubrick:${RELEASE_BRANCH} --head ${SCHEMA_VERSION} -m "$1"
 }
  
 main(){

--- a/make-release.sh
+++ b/make-release.sh
@@ -88,11 +88,20 @@ exportEnvironmentVariables() {
     export CHANNELS=$CHANNEL
     
 }
+
+commitChanges() {
+  echo "[INFO] Pushing changes to $SCHEMA_VERSION branch"
+  git add -A
+  git commit -s -m "$1"
+  git push origin $SCHEMA_VERSION
+}
  
 main(){
+  checkoutToReleaseBranch
   updateVersionNumbers
   exportEnvironmentVariables
   make bundle
+  commitChanges "chore(release): release version ${SCHEMA_VERSION}"
 }
 
 main

--- a/make-release.sh
+++ b/make-release.sh
@@ -72,10 +72,10 @@ checkoutToReleaseBranch() {
   echo "[INFO] Checking out to $SCHEMA_VERSION branch."
   if git ls-remote -q --heads | grep -q $SCHEMA_VERSION ; then
     echo "[INFO] $SCHEMA_VERSION exists."
-    resetChanges $SCHEMA_VERSION --- commented out so it doesnt delete my work when testing
+    resetChanges $SCHEMA_VERSION
   else
     echo "[INFO] $SCHEMA_VERSION does not exist. Will create a new one from main."
-    resetChanges release-automation --- commented out so it doesnt delete my work when testing #change release-automation to main after testing
+    resetChanges release-automation #change release-automation to main after testing
     git push origin release-automation:$SCHEMA_VERSION
   fi
   git checkout -B $SCHEMA_VERSION
@@ -134,10 +134,11 @@ verifyReleaseBranch() {
 
 createPullRequest(){
   echo "[INFO] Creating a PR"
-  hub pull-request --base jdubrick:${RELEASE_BRANCH} --head ${SCHEMA_VERSION} -m "$1"
+  hub pull-request --base jdubrick:${RELEASE_BRANCH} --head ${SCHEMA_VERSION} -m "$1" #jdubrick changes to devfile
 }
  
 main(){
+  #setUpstream -- LEAVE COMMENTED AS THIS WILL SET MY ORIGIN TO DEVFILE
   checkoutToReleaseBranch
   updateVersionNumbers
   exportEnvironmentVariables
@@ -145,8 +146,6 @@ main(){
   commitChanges "chore(release): release version ${SCHEMA_VERSION}"
   verifyReleaseBranch
   createPullRequest "v${SCHEMA_VERSION} Release"
-  
-  #setUpstream -- LEAVE COMMENTED AS THIS WILL SET MY ORIGIN TO DEVFILE
 }
 
 main

--- a/make-release.sh
+++ b/make-release.sh
@@ -102,23 +102,30 @@ commitChanges() {
 # with the name release-vX
 ## This func will be used when we have a new major release and there is no branch in the upstream repo
 createNewReleaseBranch(){
-  git checkout -b "${RELEASE_BRANCH}"
+  git checkout -b "${RELEASE_BRANCH}" main
   git push origin "${RELEASE_BRANCH}"
-  hub sync
+  #hub sync
 }
 
 createPullRequest(){
   echo "[INFO] Creating a PR"
-  hub pull-request --base ${RELEASE_BRANCH} --head ${SCHEMA_VERSION} -m "$1"
+  hub pull-request --base jdubrick:${RELEASE_BRANCH} --head ${SCHEMA_VERSION} -m "$1"
 }
  
 main(){
-  checkoutToReleaseBranch
-  updateVersionNumbers
-  exportEnvironmentVariables
-  make bundle
-  commitChanges "chore(release): release version ${SCHEMA_VERSION}"
-  createPullRequest "v${SCHEMA_VERSION} Release"
+  # checkoutToReleaseBranch
+  # updateVersionNumbers
+  # exportEnvironmentVariables
+  # make bundle
+  # commitChanges "chore(release): release version ${SCHEMA_VERSION}"
+  #createPullRequest "v${SCHEMA_VERSION} Release"
+  # Check if the branch exists in the remote repository
+  if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" >/dev/null 2>&1; then
+      echo "Branch $RELEASE_BRANCH exists in the remote repository."
+  else
+      echo "Branch $RELEASE_BRANCH does not exist in the remote repository."
+      createNewReleaseBranch
+  fi
 }
 
 main

--- a/make-release.sh
+++ b/make-release.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+#
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+usage ()
+{   echo "Usage: ./make-release.sh <schema-version>"
+    exit
+}
+
+if [[ $# -lt 1 ]]; then usage; fi
+SCHEMA_VERSION=$1
+
+if ! command -v hub > /dev/null; then
+  echo "[ERROR] The hub CLI needs to be installed. See https://github.com/github/hub/releases"
+  exit
+fi
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+  echo "[ERROR] The GITHUB_TOKEN environment variable must be set."
+  exit
+fi
+if ! [[ "$SCHEMA_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+	echo >&2 "$SCHEMA_VERSION isn't a valid semver tag for the schema. Aborting..."
+	exit 1
+fi
+
+
+## Ensures local branch matches the remote
+resetChanges() {
+  echo "[INFO] Reset changes in $1 branch"
+  git reset --hard
+  git checkout $1
+  git fetch origin --prune
+  git pull origin $1
+}
+
+## Branch containing releases and tags in main upstream repo will be named 'release-vx' where 'vx' is the major release
+## All minor and patch releases will be contained within a major release branch
+## On the local side (the release engineers), the branches will be their full versioning name e.g. x.x.x
+## Local branch will create a PR to its respective major release branch (if exists) or create a new one
+checkoutToReleaseBranch() {
+  echo "[INFO] Checking out to $SCHEMA_VERSION branch."
+  if git ls-remote -q --heads | grep -q $SCHEMA_VERSION ; then
+    echo "[INFO] $SCHEMA_VERSION exists."
+    #resetChanges $SCHEMA_VERSION --- commented out so it doesnt delete my work when testing
+  else
+    echo "[INFO] $SCHEMA_VERSION does not exist. Will create a new one from main."
+    #resetChanges main --- commented out so it doesnt delete my work when testing
+    git push origin main:$SCHEMA_VERSION
+  fi
+  git checkout -B $SCHEMA_VERSION
+}
+
+
+updateVersionNumbers() {
+    SHORT_UNAME=$(uname -s)
+
+    ## Updating version.md based off of operating system
+  if [ "$(uname)" == "Darwin" ]; then
+    sed -i '' "s/^.*$/$SCHEMA_VERSION/" VERSION
+  elif [ "${SHORT_UNAME:0:5}" == "Linux" ]; then
+    sed -i "s/^.*$/$SCHEMA_VERSION/" VERSION
+  fi
+
+    ## Remaining version number updates to yaml files
+    yq eval ".metadata.annotations.containerImage = \"quay.io/devfile/registry-operator:$SCHEMA_VERSION\"" --inplace ./config/manifests/bases/registry-operator.clusterserviceversion.yaml
+    yq eval ".metadata.name = \"registry-operator.v$SCHEMA_VERSION\"" --inplace ./config/manifests/bases/registry-operator.clusterserviceversion.yaml
+    yq eval ".spec.version = \"$SCHEMA_VERSION\"" --inplace ./config/manifests/bases/registry-operator.clusterserviceversion.yaml
+}
+
+exportEnvironmentVariables() {
+    CHANNEL=$(yq eval '.annotations."operators.operatorframework.io.bundle.channels.v1"' ./bundle/metadata/annotations.yaml)
+    export IMG=quay.io/devfile/registry-operator:$SCHEMA_VERSION
+    export CHANNELS=$CHANNEL
+    
+}
+ 
+main(){
+  updateVersionNumbers
+  exportEnvironmentVariables
+  make bundle
+}
+
+main

--- a/replace-alm-examples.sh
+++ b/replace-alm-examples.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ALM_EXAMPLES=$(yq -r '.metadata.annotations.alm-examples' ./config/manifests/bases/registry-operator.clusterserviceversion.yaml)
+yq -i ".metadata.annotations.alm-examples = ($ALM_EXAMPLES | to_json)" ./bundle/manifests/registry-operator.clusterserviceversion.yaml


### PR DESCRIPTION
**Please specify the area for this PR**
Release automation

**What does does this PR do / why we need it**:
This PR automates the tasks undertaken during the release process for `registry-operator`. It replaces all of the version numbers with the new release version, commits the changes, and opens a pull request for the release to the proper release branch. If the new release being cut is a major this script will create a new branch to house this new major release. For all minor and patch releases it will open the PR to its respective branch.

Updating the release process documentation was not in the acceptance criteria for this issue so I have opened an issue to address changes to be made: https://github.com/devfile/api/issues/1421

**Which issue(s) this PR fixes**:
fixes https://github.com/devfile/api/issues/1326

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
After changes to the old release is made to include the entire git history we will need to do a sanity check test to ensure the script can access the devfile repo properly. All testing up to this point has been to a forked repo and I am unsure if there will be any unforeseen complications with permissions when going to devfile.

Until these changes and sanity check has been made we should not merge this PR.

cc: @michael-valdron 
