### PR TITLE
Add Documentation For Minikube and MacOS Deployment

### DIFF
--- a/DEVFILE_REGISTRY.md
+++ b/DEVFILE_REGISTRY.md
@@ -206,3 +206,16 @@ spec:
     ingressDomain: $INGRESS_DOMAIN
 EOF
 ```
+## Accessing the Deployed Registry
+
+After the devfile registry is deployed to the cluster you can access it via the `ingressDomain` you set. If you deployed to Minikube and are currently working on MacOS and you find trying to connect via the `ingressDomain` is timing out, please see [MacOS Troubleshooting](#macos-troubleshooting).
+
+## MacOS Troubleshooting
+
+Currently there is an issue with Minikube and MacOS where you cannot connect to a cluster using an ingress service. If this occurs you can follow these steps to access your cluster:
+1. Edit `/etc/hosts` to map `127.0.0.1` to your `ingressDomain`. Typically this is set to your Minikube ip, however, MacOS needs localhost.
+2. Open a new terminal and run `minikube tunnel`. This opens a route using the cluster's ip address.
+3. In a different terminal than the one you ran `minikube tunnel` in, run `minikube service devfile-registry --url -n <namespace of the registry>`. This will output 3 ips including ports. 
+4. The ip addresses and ports listed in step 4 are used to access your registry. The ports are the most important here as you can access the registry with `127.0.0.1:<port>` or `<ingressDomain>:<port>`
+
+From testing, majority of the time the first `<ip>:<port>` directs you to `/viewer` so you can view the registry in your browser. If this differs you will need to try them all.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ make install && make deploy
 
 The operator will be installed under the `registry-operator-system` namespace. However, devfile registries can be deployed in any namespace.
 
+## Deploying registry to a cluster
 
+After the operator has been installed to a cluster you can deploy a devfile registry by following [these instructions](DEVFILE_REGISTRY.md).
 ## Development
 
 The repository contains a Makefile; building and deploying can be configured via the environment variables


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:
This PR expands on our documentation relating to deploying a devfile registry to a cluster. There is currently an issue where the steps required to access a deployed registry differ based on OS. This fix adds special troubleshooting steps for those users on MacOS.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/1448

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
