### PR TITLE
Add ingressClass CRD field

### DIFF
--- a/api/v1alpha1/devfileregistry_types.go
+++ b/api/v1alpha1/devfileregistry_types.go
@@ -122,7 +122,7 @@ type DevfileRegistrySpecK8sOnly struct {
 	// Ingress domain for a Kubernetes cluster. This MUST be explicitly specified on Kubernetes. There are no defaults
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	IngressDomain string `json:"ingressDomain,omitempty"`
-	// Ingress class for a Kubernetes cluster. This MUST be explicitly specified on Kubernetes. There are no defaults
+	// Ingress class for a Kubernetes cluster. Defaults to nginx.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	IngressClass string `json:"ingressClass,omitempty"`
 }

--- a/api/v1alpha1/devfileregistry_types.go
+++ b/api/v1alpha1/devfileregistry_types.go
@@ -122,6 +122,9 @@ type DevfileRegistrySpecK8sOnly struct {
 	// Ingress domain for a Kubernetes cluster. This MUST be explicitly specified on Kubernetes. There are no defaults
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	IngressDomain string `json:"ingressDomain,omitempty"`
+	// Ingress class for a Kubernetes cluster. This MUST be explicitly specified on Kubernetes. There are no defaults
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	IngressClass string `json:"ingressClass,omitempty"`
 }
 
 // Telemetry defines the desired state for telemetry in the DevfileRegistry

--- a/config/crd/bases/registry.devfile.io_devfileregistries.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistries.yaml
@@ -72,12 +72,12 @@ spec:
                 description: DevfileRegistrySpecK8sOnly defines the desired state
                   of the kubernetes-only fields of the DevfileRegistry
                 properties:
+                  ingressClass:
+                    description: Ingress class for a Kubernetes cluster. Defaults
+                      to nginx.
+                    type: string
                   ingressDomain:
                     description: Ingress domain for a Kubernetes cluster. This MUST
-                      be explicitly specified on Kubernetes. There are no defaults
-                    type: string
-                  ingressClass:
-                    description: Ingress class for a Kubernetes cluster. This MUST
                       be explicitly specified on Kubernetes. There are no defaults
                     type: string
                 type: object

--- a/config/crd/bases/registry.devfile.io_devfileregistries.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistries.yaml
@@ -76,6 +76,10 @@ spec:
                     description: Ingress domain for a Kubernetes cluster. This MUST
                       be explicitly specified on Kubernetes. There are no defaults
                     type: string
+                  ingressClass:
+                    description: Ingress class for a Kubernetes cluster. This MUST
+                      be explicitly specified on Kubernetes. There are no defaults
+                    type: string
                 type: object
               ociRegistry:
                 description: Sets the OCI registry container spec to be deployed on

--- a/pkg/registry/defaults.go
+++ b/pkg/registry/defaults.go
@@ -57,6 +57,9 @@ const (
 	OCIMetricsPort              = 5001
 	OCIServerPort               = 5000
 	RegistryViewerPort          = 3000
+
+	// Default kubernetes-only fields
+	DefaultK8sIngressClass = "nginx"
 )
 
 // GetRegistryViewerImage returns the container image for the registry viewer to be deployed on the Devfile Registry.
@@ -157,6 +160,15 @@ func GetDevfileRegistryVolumeSource(cr *registryv1alpha1.DevfileRegistry) corev1
 	}
 	// If persistence is not enabled, return an empty dir volume source
 	return corev1.VolumeSource{}
+}
+
+// GetK8sIngressClass returns ingress class used for the k8s ingress class field.
+// Default: "nginx"
+func GetK8sIngressClass(cr *registryv1alpha1.DevfileRegistry) string {
+	if cr.Spec.K8s.IngressClass != "" {
+		return cr.Spec.K8s.IngressClass
+	}
+	return DefaultK8sIngressClass
 }
 
 // IsStorageEnabled returns true if storage.enabled is set in the DevfileRegistry CR

--- a/pkg/registry/defaults_test.go
+++ b/pkg/registry/defaults_test.go
@@ -429,3 +429,40 @@ func Test_getDevfileRegistrySpecContainer(t *testing.T) {
 		})
 	}
 }
+
+func TestGetK8sIngressClass(t *testing.T) {
+	tests := []struct {
+		name string
+		cr   registryv1alpha1.DevfileRegistry
+		want string
+	}{
+		{
+			name: "Case 1: K8s ingress class set",
+			cr: registryv1alpha1.DevfileRegistry{
+				Spec: registryv1alpha1.DevfileRegistrySpec{
+					K8s: registryv1alpha1.DevfileRegistrySpecK8sOnly{
+						IngressClass: "test",
+					},
+				},
+			},
+			want: "test",
+		},
+		{
+			name: "Case 2: K8s ingress class not set",
+			cr: registryv1alpha1.DevfileRegistry{
+				Spec: registryv1alpha1.DevfileRegistrySpec{
+					Telemetry: registryv1alpha1.DevfileRegistrySpecTelemetry{},
+				},
+			},
+			want: DefaultK8sIngressClass,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetK8sIngressClass(&tt.cr)
+			if result != tt.want {
+				t.Errorf("func TestGetK8sIngressClass(t *testing.T) {\n error: enablement value mismatch, expected: %v got: %v", tt.want, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Please specify the area for this PR**

This PR adds support for the CRD field of the ingress class in the `registry-operator`.

**What does does this PR do / why we need it**:

fixes https://github.com/devfile/api/issues/1434

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
