### PR TITLE
Update Ingress and Hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,5 @@ Please see our [contributing.md](./CONTRIBUTING.md).
 
 ## Known Issues
 - [`make test-integration` times out when running in Minikube](https://github.com/devfile/api/issues/1313)
+- [Headless mode field does not update devfile registry state during reconcile](https://github.com/devfile/api/issues/1258)
+- [`make bundle` removes `alm-examples` for `DevfileRegistriesList` and `ClusterDevfileRegistriesList` CRDs due to bug with Kustomize](https://github.com/kubernetes-sigs/kustomize/issues/5042)

--- a/README.md
+++ b/README.md
@@ -174,3 +174,6 @@ make run ENABLE_WEBHOOKS=false
 ## Contributing
 
 Please see our [contributing.md](./CONTRIBUTING.md).
+
+## Known Issues
+- [`make test-integration` times out when running in Minikube](https://github.com/devfile/api/issues/1313)

--- a/pkg/registry/ingress.go
+++ b/pkg/registry/ingress.go
@@ -17,6 +17,8 @@
 package registry
 
 import (
+	"fmt"
+
 	registryv1alpha1 "github.com/devfile/registry-operator/api/v1alpha1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -70,5 +72,9 @@ func GenerateIngress(cr *registryv1alpha1.DevfileRegistry, host string, scheme *
 }
 
 func GetDevfileRegistryIngress(cr *registryv1alpha1.DevfileRegistry) string {
-	return cr.Name + "." + cr.Spec.K8s.IngressDomain
+	return GetHostname(cr) + "." + cr.Spec.K8s.IngressDomain
+}
+
+func GetHostname(cr *registryv1alpha1.DevfileRegistry) string {
+	return fmt.Sprintf("%s-%s", cr.Name, cr.Namespace)
 }

--- a/pkg/registry/ingress_test.go
+++ b/pkg/registry/ingress_test.go
@@ -1,0 +1,85 @@
+//
+//
+// Copyright Red Hat
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"testing"
+
+	registryv1alpha1 "github.com/devfile/registry-operator/api/v1alpha1"
+)
+
+func TestGetDevfileRegistryIngress(t *testing.T) {
+
+	tests := []struct {
+		name string
+		cr   registryv1alpha1.DevfileRegistry
+		want string
+	}{
+		{
+			name: "Case 1: Correct Conjunction",
+			cr: registryv1alpha1.DevfileRegistry{
+				Spec: registryv1alpha1.DevfileRegistrySpec{
+					K8s: registryv1alpha1.DevfileRegistrySpecK8sOnly{
+						IngressDomain: "my-domain",
+					},
+				}},
+			want: "test-name-test-namespace.my-domain",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.cr.Name = "test-name"
+			tt.cr.Namespace = "test-namespace"
+			ingress := GetDevfileRegistryIngress(&tt.cr)
+			if ingress != tt.want {
+				t.Errorf("expected: %v got: %v", tt.want, ingress)
+			}
+		})
+	}
+
+}
+
+func TestGetHostname(t *testing.T) {
+
+	tests := []struct {
+		name string
+		cr   registryv1alpha1.DevfileRegistry
+		want string
+	}{
+		{
+			name: "Case 1: Correct Hostname",
+			cr: registryv1alpha1.DevfileRegistry{
+				Spec: registryv1alpha1.DevfileRegistrySpec{
+					K8s: registryv1alpha1.DevfileRegistrySpecK8sOnly{
+						IngressDomain: "my-domain",
+					},
+				}},
+			want: "test-name-test-namespace",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.cr.Name = "test-name"
+			tt.cr.Namespace = "test-namespace"
+			hostname := GetHostname(&tt.cr)
+			if hostname != tt.want {
+				t.Errorf("expected: %v got: %v", tt.want, hostname)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:
This PR updates the operator hostname to be consistent in its definition between the Helm deployment and the openshift deployment. Prior to this change the Helm chart implemented the CR name coupled with the namespace to create the hostname whereas the openshift deployment only used the CR name and the ingress.

Additionally the readme was updated with a `Known Issues` section as during testing I was trying to run `make test-integration` on Minikube, however, it was timing out and I could not figure out why this was happening. There was an active issue that outlined this and it would be good for others to be aware of known issues such as this in the future.

Some unit tests were also added to verify that the functions used to generate the combination of the hostname/ingress/name are working as intended. 

**Which issue(s) this PR fixes**:

fixes https://github.com/devfile/api/issues/1431

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
- [ ] `make test` passes
- [ ] `make test-integration` passes