### PR TITLE
Add override CRD fields

### DIFF
--- a/api/v1alpha1/devfileregistry_types.go
+++ b/api/v1alpha1/devfileregistry_types.go
@@ -70,6 +70,18 @@ type DevfileRegistrySpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
 	Headless *bool `json:"headless,omitempty"`
+	// Overrides the entire hostname and domain of the devfile registry ingress
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +optional
+	HostnameOverride string `json:"hostnameOverride,omitempty"`
+	// Overrides the app name of the devfile registry
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +optional
+	NameOverride string `json:"nameOverride,omitempty"`
+	// Overrides the fully qualified app name of the devfile registry
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +optional
+	FullnameOverride string `json:"fullnameOverride,omitempty"`
 }
 
 // DevfileRegistrySpecContainer defines the desired state of a container for the DevfileRegistry

--- a/config/crd/bases/registry.devfile.io_devfileregistries.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistries.yaml
@@ -64,10 +64,18 @@ spec:
                 description: Sets the container image containing devfile stacks to
                   be deployed on the Devfile Registry
                 type: string
+              fullnameOverride:
+                description: Overrides the fully qualified app name of the devfile
+                  registry
+                type: string
               headless:
                 description: Sets the registry server deployment to run under headless
                   mode
                 type: boolean
+              hostnameOverride:
+                description: Overrides the entire hostname and domain of the devfile
+                  registry ingress
+                type: string
               k8s:
                 description: DevfileRegistrySpecK8sOnly defines the desired state
                   of the kubernetes-only fields of the DevfileRegistry
@@ -81,6 +89,9 @@ spec:
                       be explicitly specified on Kubernetes. There are no defaults
                     type: string
                 type: object
+              nameOverride:
+                description: Overrides the app name of the devfile registry
+                type: string
               ociRegistry:
                 description: Sets the OCI registry container spec to be deployed on
                   the Devfile Registry

--- a/pkg/registry/defaults.go
+++ b/pkg/registry/defaults.go
@@ -60,6 +60,11 @@ const (
 
 	// Default kubernetes-only fields
 	DefaultK8sIngressClass = "nginx"
+
+	// Override defaults (should be empty)
+	DefaultHostnameOverride = ""
+	DefaultNameOverride     = ""
+	DefaultFullnameOverride = ""
 )
 
 // GetRegistryViewerImage returns the container image for the registry viewer to be deployed on the Devfile Registry.
@@ -169,6 +174,36 @@ func GetK8sIngressClass(cr *registryv1alpha1.DevfileRegistry) string {
 		return cr.Spec.K8s.IngressClass
 	}
 	return DefaultK8sIngressClass
+}
+
+// GetHostnameOverride returns hostname override used to override the hostname and domain of a devfile registry
+// Default: ""
+func GetHostnameOverride(cr *registryv1alpha1.DevfileRegistry) string {
+	if cr.Spec.HostnameOverride != "" {
+		return cr.Spec.HostnameOverride
+	}
+
+	return DefaultHostnameOverride
+}
+
+// GetNameOverride returns name override used to override the app name of a devfile registry
+// Default: ""
+func GetNameOverride(cr *registryv1alpha1.DevfileRegistry) string {
+	if cr.Spec.NameOverride != "" {
+		return cr.Spec.NameOverride
+	}
+
+	return DefaultNameOverride
+}
+
+// GetFullnameOverride returns full name override used to override the fully qualified app name of a devfile registry
+// Default: ""
+func GetFullnameOverride(cr *registryv1alpha1.DevfileRegistry) string {
+	if cr.Spec.FullnameOverride != "" {
+		return cr.Spec.FullnameOverride
+	}
+
+	return DefaultFullnameOverride
 }
 
 // IsStorageEnabled returns true if storage.enabled is set in the DevfileRegistry CR

--- a/pkg/registry/defaults_test.go
+++ b/pkg/registry/defaults_test.go
@@ -466,3 +466,96 @@ func TestGetK8sIngressClass(t *testing.T) {
 		})
 	}
 }
+
+func TestGetHostnameOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		cr   registryv1alpha1.DevfileRegistry
+		want string
+	}{
+		{
+			name: "Case 1: Hostname override is set",
+			cr: registryv1alpha1.DevfileRegistry{
+				Spec: registryv1alpha1.DevfileRegistrySpec{
+					HostnameOverride: "192.168.1.123.nip.io",
+				},
+			},
+			want: "192.168.1.123.nip.io",
+		},
+		{
+			name: "Case 2: Hostname override is unset",
+			cr:   registryv1alpha1.DevfileRegistry{},
+			want: DefaultHostnameOverride,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetHostnameOverride(&tt.cr)
+			if result != tt.want {
+				t.Errorf("func TestGetHostnameOverride(t *testing.T) {\n error: enablement value mismatch, expected: %v got: %v", tt.want, result)
+			}
+		})
+	}
+}
+
+func TestGetNameOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		cr   registryv1alpha1.DevfileRegistry
+		want string
+	}{
+		{
+			name: "Case 1: App name override is set",
+			cr: registryv1alpha1.DevfileRegistry{
+				Spec: registryv1alpha1.DevfileRegistrySpec{
+					NameOverride: "devfile-registry-test",
+				},
+			},
+			want: "devfile-registry-test",
+		},
+		{
+			name: "Case 2: App name override is unset",
+			cr:   registryv1alpha1.DevfileRegistry{},
+			want: DefaultNameOverride,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetNameOverride(&tt.cr)
+			if result != tt.want {
+				t.Errorf("func TestGetNameOverride(t *testing.T) {\n error: enablement value mismatch, expected: %v got: %v", tt.want, result)
+			}
+		})
+	}
+}
+
+func TestGetFullnameOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		cr   registryv1alpha1.DevfileRegistry
+		want string
+	}{
+		{
+			name: "Case 1: Full app name override is set",
+			cr: registryv1alpha1.DevfileRegistry{
+				Spec: registryv1alpha1.DevfileRegistrySpec{
+					FullnameOverride: "devfile-registry-test",
+				},
+			},
+			want: "devfile-registry-test",
+		},
+		{
+			name: "Case 2: Full app name override is unset",
+			cr:   registryv1alpha1.DevfileRegistry{},
+			want: DefaultFullnameOverride,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetFullnameOverride(&tt.cr)
+			if result != tt.want {
+				t.Errorf("func TestGetFullnameOverride(t *testing.T) {\n error: enablement value mismatch, expected: %v got: %v", tt.want, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Please specify the area for this PR**

operator api

**What does does this PR do / why we need it**:

Adds override fields from the helm chart to the `DevfileRegistry` CRD:
- `hostnameOverride`
- `nameOverride`
- `fullnameOverride`

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1439

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [x] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
