### PR TITLE
Fix `setup-envtest` version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/devfile/registry-operator:next
+# ENVTEST_VERSION refers to the version of the setup-envtest binary to use
+ENVTEST_VERSION=v0.0.0-20240405143037-c25fe2f5ca0f
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26
 # Controller tools version number
@@ -259,7 +261,7 @@ $(KUSTOMIZE): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) GOFLAGS="" go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) GOFLAGS="" go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle


### PR DESCRIPTION
**Please specify the area for this PR**

operator 
test

**What does does this PR do / why we need it**:

Fixes `sigs.k8s.io/controller-runtime/tools/setup-envtest` to revision `v0.0.0-20240405143037-c25fe2f5ca0f` to workaround https://github.com/kubernetes-sigs/controller-runtime/issues/2744.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1519

**PR acceptance criteria**:

- [X] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [x] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
