### PR TITLE
Multi Arch Support for Registry Operator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,7 @@ jobs:
       uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 #v3.0.0
 
     - name: Check if operator docker build is working
-      run: docker build -f Dockerfile .
+      run: make docker-buildx
 
   operator-bundle-build:
     name: Check operator bundle build
@@ -136,4 +136,4 @@ jobs:
       uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 #v3.0.0
     
     - name: Build the operator's bundle image
-      run: make bundle-build
+      run: make docker-bundle-buildx

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,9 +108,6 @@ jobs:
     name: Check operator container image build
     runs-on: ubuntu-latest
 
-    env:
-      PUSH_IMAGE: false
-    
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -119,15 +116,12 @@ jobs:
       uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 #v3.0.0
 
     - name: Check if operator docker build is working
-      run: make docker-buildx
+      run: make docker-buildx-build
 
   operator-bundle-build:
     name: Check operator bundle build
     runs-on: ubuntu-latest
 
-    env:
-      PUSH_IMAGE: false
-    
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -136,4 +130,4 @@ jobs:
       uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 #v3.0.0
     
     - name: Build the operator's bundle image
-      run: make docker-bundle-buildx
+      run: make docker-bundle-buildx-build

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,10 @@ jobs:
   operator-build:
     name: Check operator container image build
     runs-on: ubuntu-latest
+
+    env:
+      PUSH_IMAGE: false
+    
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
@@ -120,6 +124,10 @@ jobs:
   operator-bundle-build:
     name: Check operator bundle build
     runs-on: ubuntu-latest
+
+    env:
+      PUSH_IMAGE: false
+    
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -108,20 +108,24 @@ jobs:
     name: Check operator container image build
     runs-on: ubuntu-latest
     steps:
-    -
-      name: Check out code into the Go module directory
+    - name: Check out code into the Go module directory
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    -
-      name: Check if operator docker build is working
+
+    - name: Set up QEMU # Enables arm64 image building
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 #v3.0.0
+
+    - name: Check if operator docker build is working
       run: docker build -f Dockerfile .
 
   operator-bundle-build:
     name: Check operator bundle build
     runs-on: ubuntu-latest
     steps:
-    -
-      name: Check out code into the Go module directory
+    - name: Check out code into the Go module directory
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    -
-      name: Build the operator's bundle image
+
+    - name: Set up QEMU # Enables arm64 image building
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 #v3.0.0
+    
+    - name: Build the operator's bundle image
       run: make bundle-build

--- a/.github/workflows/dockerimage-push.yaml
+++ b/.github/workflows/dockerimage-push.yaml
@@ -35,8 +35,8 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
-    - name: Docker Buildx - Operator
-      run: "make docker-buildx"
+    - name: Build and push Operator with Docker Buildx
+      run: "make docker-buildx-push"
         
   push-operator-bundle:
     runs-on: ubuntu-latest
@@ -54,5 +54,5 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
 
-    - name: Docker Buildx - Bundle
-      run: "make docker-bundle-buildx"
+    - name: Build and push bundle with Docker Buildx
+      run: "make docker-bundle-buildx-push"

--- a/.github/workflows/dockerimage-push.yaml
+++ b/.github/workflows/dockerimage-push.yaml
@@ -19,35 +19,40 @@ on:
     branches: [ main ]
 
 jobs:
-
   push-operator-image:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout registry-operator source code
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    - name: Docker Build & Push - Registry Operator Image
-      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1.1.2
+
+    - name: Set up QEMU # Enables arm64 image building
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 #v3.0.0
+
+    - name: Login to Quay.io
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
       with:
+        registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
-        registry: quay.io
-        repository: devfile/registry-operator
-        dockerfile: Dockerfile
-        tags: next
-        tag_with_sha: true
+
+    - name: Docker Buildx - Operator
+      run: "make docker-buildx"
         
   push-operator-bundle:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout registry-operator source code
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-    - name: Build and push the Registry Operator Bundle to quay.io
-      uses: docker/build-push-action@3e7a4f6646880c6f63758d73ac32392d323eaf8f # v1.1.2
+
+    - name: Set up QEMU # Enables arm64 image building
+      uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 #v3.0.0
+
+    - name: Login to Quay.io
+      uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
       with:
+        registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
-        registry: quay.io
-        repository: devfile/registry-operator-bundle
-        dockerfile: bundle.Dockerfile
-        tags: next
-        tag_with_sha: true
+
+    - name: Docker Buildx - Bundle
+      run: "make docker-bundle-buildx"

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ The repository contains a Makefile; building and deploying can be configured via
 | `ENVTEST` | Path to target `setup-envtest` binary | `${LOCALBIN}/setup-envtest` |
 | `TARGET_ARCH` | Target architecture for operator manager builds, possible values: `amd64`, `arm64`, `s390x`, `ppc64le` | `amd64` |
 | `TARGET_OS` | Target operating system for operator manager build, **only for `make manager`** | `linux` |
-| `PUSH_IMAGE` | Controls whether or not `make docker-buildx`, `make docker-bundle-buildx` or `make podman-buildx` push to an external repository. If `false` they will only build. | `true` |
 | `PLATFORMS` | Target architecture(s) for `make docker-buildx` | All supported: `linux/arm64,linux/amd64,linux/s390x,linux/ppc64le` |
 | `KUSTOMIZE_INSTALL_SCRIPT` | URL of kustomize installation script, see [kustomize installation instructions](https://kubectl.docs.kubernetes.io/installation/kustomize/binaries/) | `https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh` |
 
@@ -110,9 +109,12 @@ Some of the rules supported by the makefile:
 | kustomize | install the kustomize tool, used by other commands |
 | docker-build | build registry operator container image using docker |
 | docker-push | push registry operator container image using docker |
-| docker-buildx | build & push registry operator docker image for all supported architectures using docker|
-| docker-bundle-buildx | build & push registry operator bundle docker image for all supported architectures using docker|
-| podman-buildx | build & push registry operator docker image for all supported architectures using podman|
+| docker-buildx-build | build registry operator docker image for all supported architectures using docker|
+| docker-buildx-push | build & push registry operator docker image for all supported architectures using docker|
+| docker-bundle-buildx-build | build registry operator bundle docker image for all supported architectures using docker|
+| docker-bundle-buildx-push | build & push registry operator bundle docker image for all supported architectures using docker|
+| podman-buildx-build | build registry operator docker image for all supported architectures using podman|
+| podman-buildx-push | push registry operator docker image for all supported architectures using podman|
 | podman-build | build registry operator container image using podman |
 | podman-push | push registry operator container image using podman |
 | deploy | deploy operator to cluster |

--- a/README.md
+++ b/README.md
@@ -97,8 +97,10 @@ The repository contains a Makefile; building and deploying can be configured via
 | `ENVTEST` | Path to target `setup-envtest` binary | `${LOCALBIN}/setup-envtest` |
 | `TARGET_ARCH` | Target architecture for operator manager builds, possible values: `amd64`, `arm64`, `s390x`, `ppc64le` | `amd64` |
 | `TARGET_OS` | Target operating system for operator manager build, **only for `make manager`** | `linux` |
+| `PUSH_IMAGE` | Controls whether or not `make docker-buildx`, `make docker-bundle-buildx` or `make podman-buildx` push to an external repository. If `false` they will only build. | `true` |
 | `PLATFORMS` | Target architecture(s) for `make docker-buildx` | All supported: `linux/arm64,linux/amd64,linux/s390x,linux/ppc64le` |
 | `KUSTOMIZE_INSTALL_SCRIPT` | URL of kustomize installation script, see [kustomize installation instructions](https://kubectl.docs.kubernetes.io/installation/kustomize/binaries/) | `https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh` |
+
 
 Some of the rules supported by the makefile:
 
@@ -108,7 +110,9 @@ Some of the rules supported by the makefile:
 | kustomize | install the kustomize tool, used by other commands |
 | docker-build | build registry operator container image using docker |
 | docker-push | push registry operator container image using docker |
-| docker-buildx | build & push registry operator docker image for all supported architectures |
+| docker-buildx | build & push registry operator docker image for all supported architectures using docker|
+| docker-bundle-buildx | build & push registry operator bundle docker image for all supported architectures using docker|
+| podman-buildx | build & push registry operator docker image for all supported architectures using podman|
 | podman-build | build registry operator container image using podman |
 | podman-push | push registry operator container image using podman |
 | deploy | deploy operator to cluster |


### PR DESCRIPTION
**Please specify the area for this PR**
CI and multi-arch building

**What does does this PR do / why we need it**:
This PR enables the images built for the registry-operator to be multi-arch. Previously there was a `make` command `make docker-buildx` that built and pushed multi-arch images but it was not included in any of our CI. This PR updates that command to incorporate it into our CI alongside a new command, `make docker-bundle-buildx` to allow the bundle to also be built for multiple architectures. 

Since `buildx` is a docker command I also created a `make podman-buildx` command, this is a clone of `make docker-buildx` but redesigned to work with podman and its specific commands.

Both `ci.yaml` and `dockerimage-push.yaml` were updated to now reference the `buildx` commands for building and pushing our images so that they support multiple architectures. Due to the nature of how `buildx` works with the `--push` flag, I had to create the make variable `PUSH_IMAGE` which defaults to `true`. This variable allows us to control if we want the image to be pushed to a repository or not, in the case of `ci.yaml` we only want to test the builds when a PR is opened and this enables it to do so.

**Which issue(s) this PR fixes**:

fixes https://github.com/devfile/api/issues/1549

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

<!--
Instructions for locally testing changes made to the operator, drawn from CONTRIBUTING.md
-->
**Testing changes**

[Running Unit Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#unit-tests)

[Running Integration Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#integration-tests)

<!--
Add extra instructions that reviewers may need regarding testing your changes or to properly review your pull request.
-->
**Special notes to the reviewer**:
You can test the commands locally by performing the following:

- Run `IMG=<your repo> make docker-buildx-push` to create a multi-arch operator image and have it pushed to your repo of choice
- Run `BUNDLE_IMG=<your repo> make docker-bundle-buildx-push` to create a multi-arch bundle image and have it pushed to your repo of choice
- Run `IMG=<your repo> make podman-buildx-build && make podman-buildx-push` to create a multi-arch operator image using podman and have it pushed
- Run `IMG=<your repo>` infront of `make docker-buildx-build`, or `make podman-buildx-build` to build the images but not have them pushed to your repo
     - E.g. `IMG=<your repo> make docker-buildx-build`
- Run `BUNDLE_IMG=<your repo> make docker-bundle-buildx-build` to build the bundle but not have it pushed
     