### PR TITLE
Updated cert-manager version v1.11.0---> v1.15.1   

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@
 VERSION ?= `cat $(PWD)/VERSION`
 # Default bundle image tag
 BUNDLE_IMG ?= quay.io/devfile/registry-operator-bundle:v$(VERSION)
-CERT_MANAGER_VERSION ?= v1.11.0
+CERT_MANAGER_VERSION ?= v1.15.1
 ENABLE_WEBHOOKS ?= true
 ENABLE_WEBHOOK_HTTP2 ?= false
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The repository contains a Makefile; building and deploying can be configured via
 |---|---|---|
 | `IMG` | Image used for controller (run makefile, if `IMG` is updated) | `quay.io/devfile/registry-operator:next` |
 | `BUNDLE_IMG` | Image used for bundle OLM package | `quay.io/devfile/registry-operator-bundle:<latest_version>` |
-| `CERT_MANAGER_VERSION` | Version of `cert-manager` installed using `make install-cert` | `v1.11.0` |
+| `CERT_MANAGER_VERSION` | Version of `cert-manager` installed using `make install-cert` | `v1.15.1` |
 | `ENABLE_WEBHOOKS` | If `false`, disables operator webhooks | `true` |
 | `ENABLE_WEBHOOK_HTTP2` | Overrides webhook HTTP server deployment to use http/2 if set to `true`, **not recommended** | `false` |
 | `BUNDLE_CHANNELS` | Sets the list channel(s) include bundle build under | `alpha` |


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:
cert-manager version v1.11.0---> v1.13.1 (latest version)

**Which issue(s) this PR fixes**:
Fixes # https://github.com/devfile/api/issues/1320


**PR acceptance criteria**:

- [✅  ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

<!--
Instructions for locally testing changes made to the operator, drawn from CONTRIBUTING.md
-->
**Testing changes**
```
kubectl get pods -n cert-manager
NAME                                       READY   STATUS    RESTARTS   AGE
cert-manager-67f7b4f67d-jc9dx              1/1     Running   0          2m1s
cert-manager-cainjector-564b978556-kdsnw   1/1     Running   0          2m1s
cert-manager-webhook-7d54ddf58b-ldntk      1/1     Running   0          2m1s
```

[Running Unit Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#unit-tests)

[Running Integration Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#integration-tests)

<!--
Add extra instructions that reviewers may need regarding testing your changes or to properly review your pull request.
-->
**Special notes to the reviewer**:
