### PR TITLE
Bump registry-support dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/devfile/registry-operator
 go 1.21
 
 require (
-	github.com/devfile/registry-support/index/generator v0.0.0-20240311135803-6215550f93d4
-	github.com/devfile/registry-support/registry-library v0.0.0-20240311160550-e51ee8934746
+	github.com/devfile/registry-support/index/generator v0.0.0-20240816133831-cf509ccd1a6b
+	github.com/devfile/registry-support/registry-library v0.0.0-20240816160225-30dce468d0c0
 	github.com/go-logr/logr v1.4.1
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/onsi/ginkgo/v2 v2.14.0

--- a/go.sum
+++ b/go.sum
@@ -51,10 +51,10 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/devfile/registry-support/index/generator v0.0.0-20240311135803-6215550f93d4 h1:t09mGdy31tC2YBp6kVD7x8m0jq1CyBUSYMUvrF0iaWw=
-github.com/devfile/registry-support/index/generator v0.0.0-20240311135803-6215550f93d4/go.mod h1:3Ngbmm12LW03tAEHpDNymM7zryd5H1Xo3ZAGlBpecf8=
-github.com/devfile/registry-support/registry-library v0.0.0-20240311160550-e51ee8934746 h1:VQLQguSjxcU1xtUjbqmEW6R9Ehgjk1PzG56vHnzXyEw=
-github.com/devfile/registry-support/registry-library v0.0.0-20240311160550-e51ee8934746/go.mod h1:2RRLQaOYuzh8n59euz6Bu60hFoX/LLVM9uzFOFDyOZM=
+github.com/devfile/registry-support/index/generator v0.0.0-20240816133831-cf509ccd1a6b h1:gxiifOkEJ3VHqe+YZA7/mpY+GT8/vUAHJiLLLcEkSlg=
+github.com/devfile/registry-support/index/generator v0.0.0-20240816133831-cf509ccd1a6b/go.mod h1:mcAe11pniX380MMRmQ+HykCZYSVqAEv6vr2vr/xzpbE=
+github.com/devfile/registry-support/registry-library v0.0.0-20240816160225-30dce468d0c0 h1:sgga25At5RYaGD4Tyzkzoz5fq6hTCMGFin2lBzF9Hco=
+github.com/devfile/registry-support/registry-library v0.0.0-20240816160225-30dce468d0c0/go.mod h1:6Rn3RrC590sdCOCX5AC88do9uqAh1UNJqin6BsWwYd0=
 github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2 h1:aBfCb7iqHmDEIp6fBvC/hQUddQfg+3qdYjwzaiP9Hnc=
 github.com/distribution/distribution/v3 v3.0.0-20221208165359-362910506bc2/go.mod h1:WHNsWjnIn2V1LYOrME7e8KxSeKunYHsxEm4am0BUtcI=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:
This PR bumps the `registry-support` dependencies as they received a critical security fix.

**Which issue(s) this PR fixes**:
Part of https://github.com/devfile/api/issues/1620


**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

<!--
Instructions for locally testing changes made to the operator, drawn from CONTRIBUTING.md
-->
**Testing changes**

[Running Unit Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#unit-tests)

[Running Integration Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#integration-tests)

<!--
Add extra instructions that reviewers may need regarding testing your changes or to properly review your pull request.
-->
**Special notes to the reviewer**:
