### PR TITLE
added memoryLimit_field_under_registry_operator #1429

### DIFF
--- a/controllers/update.go
+++ b/controllers/update.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -59,6 +60,15 @@ func (r *DevfileRegistryReconciler) updateDeployment(ctx context.Context, cr *re
 			indexImageContainer.ImagePullPolicy = indexImagePullPolicy
 			needsUpdating = true
 		}
+	}
+
+	if indexImageContainer.Resources.Limits.Memory().String() != cr.Spec.DevfileIndex.MemoryLimit {
+		memoryLimit, err := resource.ParseQuantity(cr.Spec.DevfileIndex.MemoryLimit)
+		if err != nil {
+			r.Log.Error(err, "Error parsing memory limit")
+		}
+		indexImageContainer.Resources.Limits[corev1.ResourceMemory] = memoryLimit
+		needsUpdating = true
 	}
 
 	ociImage := registry.GetOCIRegistryImage(cr)


### PR DESCRIPTION
# Description of Changes
 added the memoryLimit field under registry_operator  so that whenever the memory label is updated.

# Related Issue(s)
https://github.com/devfile/api/issues/1429

# Acceptance Criteria

### Tests
- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

### Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

[Running Unit Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#unit-tests)

[Running Integration Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#integration-tests)

# Notes To Reviewer
_Any notes you would like to include for the reviewer._
