### PR TITLE
pin dependencies to versions for go 1.21 and remove update flag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,10 +50,10 @@ jobs:
           fi
       - name: Check format
         run: |
-          go get -u github.com/google/addlicense@dc31ac9ffcca99c9457226366135701794b128c0
-          go install github.com/google/addlicense@dc31ac9ffcca99c9457226366135701794b128c0
-          go get -u golang.org/x/tools/cmd/goimports@0cc407e63f5fdd71499c32afa4c54382c5b48d71
-          go install golang.org/x/tools/cmd/goimports@0cc407e63f5fdd71499c32afa4c54382c5b48d71
+          go get github.com/google/addlicense@v1.1.1
+          go install github.com/google/addlicense@v1.1.1
+          go get golang.org/x/tools/cmd/goimports@v0.24.0
+          go install golang.org/x/tools/cmd/goimports@v0.24.0
           git reset HEAD --hard
 
           make fmt

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ ENVTEST_VERSION=v0.0.0-20240405143037-c25fe2f5ca0f
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26
 # Controller tools version number
-CONTROLLER_TOOLS_VERSION ?= v0.9.2
+CONTROLLER_TOOLS_VERSION ?= v0.14.0
 # Kustomize version number
 KUSTOMIZE_VERSION ?= v3.8.7
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The repository contains a Makefile; building and deploying can be configured via
 | `BUNDLE_CHANNELS` | Sets the list channel(s) include bundle build under | `alpha` |
 | `BUNDLE_DEFAULT_CHANNEL` | Sets the default channel to use when installing the bundle | |
 | `ENVTEST_K8S_VERSION` | Version of k8s to use for the test environment | `1.26` (current) |
-| `CONTROLLER_TOOLS_VERSION` | Version of the controller tools | `v0.9.2` |
+| `CONTROLLER_TOOLS_VERSION` | Version of the controller tools | `v0.14.0` |
 | `KUSTOMIZE_VERSION` | Version of kustomize | `v3.8.7` | 
 | `GOBIN` | Path to install Go binaries to | `${GOPATH}/bin` |
 | `K8S_CLI` | Path to CLI tool to use with the target cluster environment, `kubectl` or `oc` | Either `oc` or `kubectl` if installed in that order |

--- a/bundle/manifests/registry.devfile.io_clusterdevfileregistrieslists.yaml
+++ b/bundle/manifests/registry.devfile.io_clusterdevfileregistrieslists.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: registry-operator-system/registry-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: clusterdevfileregistrieslists.registry.devfile.io
 spec:

--- a/bundle/manifests/registry.devfile.io_devfileregistries.yaml
+++ b/bundle/manifests/registry.devfile.io_devfileregistries.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: devfileregistries.registry.devfile.io
 spec:

--- a/bundle/manifests/registry.devfile.io_devfileregistrieslists.yaml
+++ b/bundle/manifests/registry.devfile.io_devfileregistrieslists.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     cert-manager.io/inject-ca-from: registry-operator-system/registry-operator-serving-cert
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: devfileregistrieslists.registry.devfile.io
 spec:

--- a/config/crd/bases/registry.devfile.io_clusterdevfileregistrieslists.yaml
+++ b/config/crd/bases/registry.devfile.io_clusterdevfileregistrieslists.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: clusterdevfileregistrieslists.registry.devfile.io
 spec:

--- a/config/crd/bases/registry.devfile.io_devfileregistries.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: devfileregistries.registry.devfile.io
 spec:

--- a/config/crd/bases/registry.devfile.io_devfileregistrieslists.yaml
+++ b/config/crd/bases/registry.devfile.io_devfileregistrieslists.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   name: devfileregistrieslists.registry.devfile.io
 spec:


### PR DESCRIPTION
# Description of Changes
_Summarize the changes you made as part of this PR._

This PR removes the `-u` flag from our `go get` statements and also changes the pins from sha to a version to make it easier to identify what we are running on. Both of these versions have `go.mod` files that only contain dependencies for go 1.21 or earlier so we won't encounter the issue of requiring go 1.22+ anymore. 

Since we are not always going to be on the latest Go version (historically have been lagging behind by a version or two) it is best to remove the `-u` flag to ensure we don't encounter this issue again where some dependency outpaces our Go version.


# Related Issue(s)
_Link the GitHub/GitLab/JIRA issues that are related to this PR._

resolves https://github.com/devfile/api/issues/1643

# Acceptance Criteria

### Tests
- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [ ] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

### Documentation
- [ ] Does the registry operator documentation need to be updated with your changes?

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

[Running Unit Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#unit-tests)

[Running Integration Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#integration-tests)

# Notes To Reviewer
_Any notes you would like to include for the reviewer._
