### PR TITLE
Update to Go 1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,7 +80,7 @@ jobs:
 
       - name: Run Gosec Security Scanner
         run: |
-          go install github.com/securego/gosec/v2/cmd/gosec@1af1d5bb49259b62e45c505db397dd2ada5d74f8
+          go install github.com/securego/gosec/v2/cmd/gosec@e0cca6fe95306b7e7790d6f1bf6a7bec6d622459 # v2.22.0
           make gosec
           if [[ $? != 0 ]]
           then

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9@sha256:e4193e71ea9f2e2504f6b4ee93cadef0fe5d7b37bba57484f4d4229801a7c063 as builder
 ARG TARGETARCH=amd64
 USER root
 
@@ -43,7 +43,7 @@ ARG ENABLE_WEBHOOK_HTTP2=false
 ENV ENABLE_WEBHOOK_HTTP2=${ENABLE_WEBHOOK_HTTP2}
 
 # Use ubi-micro as minimal base image to package the manager binary
-FROM registry.access.redhat.com/ubi9/ubi-micro:9.6
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.6@sha256:955512628a9104d74f7b3b0a91db27a6bbecdd6a1975ce0f1b2658d3cd060b98
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 1001

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM golang:1.21@sha256:b405b620c7b53ef64695c7da7c8396f411f381c1eb7da6713c585dd7eca1559b as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.22.9 as builder
 ARG TARGETARCH=amd64
+USER root
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -41,9 +42,8 @@ ENV ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}
 ARG ENABLE_WEBHOOK_HTTP2=false
 ENV ENABLE_WEBHOOK_HTTP2=${ENABLE_WEBHOOK_HTTP2}
 
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/static:nonroot-${TARGETARCH}
+# Use ubi-micro as minimal base image to package the manager binary
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.6
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 1001

--- a/Makefile
+++ b/Makefile
@@ -340,5 +340,5 @@ bundle-push:
 .PHONY: gosec
 gosec:
 	# Run this command to install gosec, if not installed:
-	# go install github.com/securego/gosec/v2/cmd/gosec@v2.14.0
+	# go install github.com/securego/gosec/v2/cmd/gosec@v2.22.0
 	gosec -no-fail -fmt=sarif -out=gosec.sarif -exclude-dir pkg/test -exclude-dir tests ./...

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 <div id="header">
 
+[![Go 1.22](https://img.shields.io/badge/1.22-blue?logo=go&labelColor=gray)](https://go.dev/doc/go1.22)
 [![Apache2.0 License](https://img.shields.io/badge/license-Apache2.0-brightgreen.svg)](LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8256/badge)](https://www.bestpractices.dev/projects/8256)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/devfile/registry-operator/badge)](https://securityscorecards.dev/viewer/?uri=github.com/devfile/registry-operator)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ security setups.
 
 ### Development
 
-- Go 1.21.x
+- Go 1.22.x
 - Docker / Podman
 - Operator SDK 1.28.x
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devfile/registry-operator
 
-go 1.21
+go 1.22
 
 require (
 	github.com/devfile/registry-support/index/generator v0.0.0-20240816133831-cf509ccd1a6b


### PR DESCRIPTION
# Description of Changes

Bumps Go version to 1.22 to patch runtime and support upcoming compatibility changes.

# Related Issue(s)

resolves https://github.com/devfile/api/issues/1694

# Acceptance Criteria

### Tests
- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [x] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

### Documentation
- [X] Does the registry operator documentation need to be updated with your changes?

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

[Running Unit Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#unit-tests)

[Running Integration Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#integration-tests)

# Notes To Reviewer
_Any notes you would like to include for the reviewer._
