### PR TITLE
Update openshift requirements under docs

### DIFF
--- a/CLUSTER_SUPPORT.md
+++ b/CLUSTER_SUPPORT.md
@@ -5,11 +5,11 @@ systems based on which Operator SDK version the registry operator
 is using as well as the API overlap between OpenShift and 
 Kubernetes. 
 
-Operator currently targets Kubernetes 1.29 API and is tested on OpenShift 4.15.
+Operator currently targets Kubernetes 1.29 API and is tested on OpenShift 4.18.
 
 ## Operator SDK
 
-Current version in use by the Registry Operator is [Operator SDK v1.28.0](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.28.0/), planned to use [Operator SDK v1.36.0](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.36.0/) ([devfile/api#1626](https://github.com/devfile/api/issues/1626)) to be in sync with target Kubernetes 1.29 version.
+Current version in use by the Registry Operator is [Operator SDK v1.28.0](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.28.0/), planned to use [Operator SDK v1.39.1](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.39.1/) ([devfile/api#1626](https://github.com/devfile/api/issues/1626)) to be in sync with target OpenShift 4.18 version.
 
 To update the Operator SDK, refer to [Upgrade SDK Version](https://sdk.operatorframework.io/docs/upgrading-sdk-version/) 
 and change the following

--- a/CLUSTER_SUPPORT.md
+++ b/CLUSTER_SUPPORT.md
@@ -5,7 +5,7 @@ systems based on which Operator SDK version the registry operator
 is using as well as the API overlap between OpenShift and 
 Kubernetes. 
 
-Operator currently targets Kubernetes 1.29 API and is tested on OpenShift 4.18.
+Operator currently targets [Kubernetes 1.29 API](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.29.md) and is tested on [OpenShift 4.18](https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html/release_notes/ocp-4-18-release-notes).
 
 ## Operator SDK
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,8 @@ This repository utilizes Release Notes to track and display changes, a changelog
 
 Deployment cluster must meet one of the following criteria:
 
-- OpenShift Container Platform (OCP) 4.15.x
-- Kubernetes 1.29.x
-
-**Note**: Though full support for OpenShift Container Platform (OCP) 4.16.x is not currently in place, it [includes Kubernetes 1.29.x APIs](https://docs.openshift.com/container-platform/4.16/release_notes/ocp-4-16-release-notes.html#ocp-4-16-admin-ack-updating_release-notes) therefore should work in theory.
+- OpenShift Container Platform (OCP) 4.15.x-4.18.x
+- Kubernetes 1.29.x-1.31.x
 
 More on the support of container orchestration systems can be 
 found [here](CLUSTER_SUPPORT.md).
@@ -181,4 +179,4 @@ Please see our [CONTRIBUTING.md](./CONTRIBUTING.md).
 - [`make test-integration` times out when running in Minikube](https://github.com/devfile/api/issues/1313)
 - [Headless mode field does not update devfile registry state during reconcile](https://github.com/devfile/api/issues/1258)
 - [`make bundle` removes `alm-examples` for `DevfileRegistriesList` and `ClusterDevfileRegistriesList` CRDs due to bug with Kustomize](https://github.com/kubernetes-sigs/kustomize/issues/5042)
-- [Operator SDK is out of sync, should be upgraded to v1.36.0](https://github.com/devfile/api/issues/1626)
+- [Operator SDK is out of sync, should be upgraded to v1.39.1](https://github.com/devfile/api/issues/1626)


### PR DESCRIPTION
# Description of Changes

Updates OpenShift requirements under the documentation to specify 4.15.x-4.18.x compatibility and indicate that the Operator is actively tested on OpenShift v4.18.

# Related Issue(s)

resolves https://github.com/devfile/api/issues/1669

# Acceptance Criteria

### Tests
- [X] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
- [X] Gosec scans 
  - Fix all MEDIUM and higher findings and/or annotate a finding per gosec instructions: https://github.com/securego/gosec#annotating-code to address why a finding is not a security issue

### Documentation
- [X] Does the registry operator documentation need to be updated with your changes?

# Tests Performed

Ran `make test-integration` on an active deployment of the current state of main. Tested against OpenShift 4.16-4.18.

# How To Test

[Running Unit Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#unit-tests)

[Running Integration Tests](https://github.com/devfile/registry-operator/blob/main/CONTRIBUTING.md#integration-tests)

# Notes To Reviewer
